### PR TITLE
Add CHANGELOG.md with github-changelog-generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2474 @@
+# Change Log
+
+## [v3.4.9](https://github.com/mishoo/UglifyJS2/tree/v3.4.9) (2018-08-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.8...v3.4.9)
+
+**Merged pull requests:**
+
+- fix corner case in `conditionals` [\#3244](https://github.com/mishoo/UglifyJS2/pull/3244) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `conditionals` [\#3243](https://github.com/mishoo/UglifyJS2/pull/3243) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `reduce\_vars` [\#3241](https://github.com/mishoo/UglifyJS2/pull/3241) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `collapse\_vars` [\#3239](https://github.com/mishoo/UglifyJS2/pull/3239) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.8](https://github.com/mishoo/UglifyJS2/tree/v3.4.8) (2018-08-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.7...v3.4.8)
+
+**Merged pull requests:**
+
+- fix corner case in `unused` [\#3234](https://github.com/mishoo/UglifyJS2/pull/3234) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `if\_return` [\#3232](https://github.com/mishoo/UglifyJS2/pull/3232) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.7](https://github.com/mishoo/UglifyJS2/tree/v3.4.7) (2018-08-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.6...v3.4.7)
+
+**Merged pull requests:**
+
+- fix corner case in `mangle` workaround for Safari [\#3230](https://github.com/mishoo/UglifyJS2/pull/3230) ([alexlamsl](https://github.com/alexlamsl))
+- clean up webkit quirks [\#3229](https://github.com/mishoo/UglifyJS2/pull/3229) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.6](https://github.com/mishoo/UglifyJS2/tree/v3.4.6) (2018-07-27)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.5...v3.4.6)
+
+**Merged pull requests:**
+
+- fix corner case in `join\_vars` [\#3224](https://github.com/mishoo/UglifyJS2/pull/3224) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `ie8` & `rename` [\#3223](https://github.com/mishoo/UglifyJS2/pull/3223) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `global\_defs` [\#3218](https://github.com/mishoo/UglifyJS2/pull/3218) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `ie8` [\#3216](https://github.com/mishoo/UglifyJS2/pull/3216) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.5](https://github.com/mishoo/UglifyJS2/tree/v3.4.5) (2018-07-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.4...v3.4.5)
+
+**Merged pull requests:**
+
+- fix corner cases in `preserve\_line` [\#3212](https://github.com/mishoo/UglifyJS2/pull/3212) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.4](https://github.com/mishoo/UglifyJS2/tree/v3.4.4) (2018-07-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.3...v3.4.4)
+
+**Merged pull requests:**
+
+- fix corner case in `ie8` [\#3207](https://github.com/mishoo/UglifyJS2/pull/3207) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.3](https://github.com/mishoo/UglifyJS2/tree/v3.4.3) (2018-07-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.2...v3.4.3)
+
+**Merged pull requests:**
+
+- implement `directives` [\#3203](https://github.com/mishoo/UglifyJS2/pull/3203) ([alexlamsl](https://github.com/alexlamsl))
+- improve `unsafe` `comparisons` [\#3200](https://github.com/mishoo/UglifyJS2/pull/3200) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.2](https://github.com/mishoo/UglifyJS2/tree/v3.4.2) (2018-06-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.1...v3.4.2)
+
+**Merged pull requests:**
+
+- fix corner case in `ie8` [\#3198](https://github.com/mishoo/UglifyJS2/pull/3198) ([alexlamsl](https://github.com/alexlamsl))
+- improve `mocha` tests [\#3195](https://github.com/mishoo/UglifyJS2/pull/3195) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `arguments` [\#3193](https://github.com/mishoo/UglifyJS2/pull/3193) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.1](https://github.com/mishoo/UglifyJS2/tree/v3.4.1) (2018-06-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.4.0...v3.4.1)
+
+**Merged pull requests:**
+
+- fix corner cases in `properties` [\#3189](https://github.com/mishoo/UglifyJS2/pull/3189) ([alexlamsl](https://github.com/alexlamsl))
+- general clean-ups [\#3175](https://github.com/mishoo/UglifyJS2/pull/3175) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.4.0](https://github.com/mishoo/UglifyJS2/tree/v3.4.0) (2018-06-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.28...v3.4.0)
+
+**Merged pull requests:**
+
+- update JetStream URL [\#3165](https://github.com/mishoo/UglifyJS2/pull/3165) ([alexlamsl](https://github.com/alexlamsl))
+- handle asynchronous test failures [\#3164](https://github.com/mishoo/UglifyJS2/pull/3164) ([alexlamsl](https://github.com/alexlamsl))
+- Add `enclose` option for \#2443 [\#3163](https://github.com/mishoo/UglifyJS2/pull/3163) ([Jiavan](https://github.com/Jiavan))
+
+## [v3.3.28](https://github.com/mishoo/UglifyJS2/tree/v3.3.28) (2018-05-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.27...v3.3.28)
+
+**Merged pull requests:**
+
+- fix corner case in `reduce\_vars` [\#3151](https://github.com/mishoo/UglifyJS2/pull/3151) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner cases with `eval\(\)` [\#3147](https://github.com/mishoo/UglifyJS2/pull/3147) ([alexlamsl](https://github.com/alexlamsl))
+- augment tests for inline source maps [\#3145](https://github.com/mishoo/UglifyJS2/pull/3145) ([alexlamsl](https://github.com/alexlamsl))
+- augment tests for `RegExp` [\#3144](https://github.com/mishoo/UglifyJS2/pull/3144) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.27](https://github.com/mishoo/UglifyJS2/tree/v3.3.27) (2018-05-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.26...v3.3.27)
+
+**Merged pull requests:**
+
+- fix corner case in `reduce\_vars` [\#3141](https://github.com/mishoo/UglifyJS2/pull/3141) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.26](https://github.com/mishoo/UglifyJS2/tree/v3.3.26) (2018-05-20)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.25...v3.3.26)
+
+**Merged pull requests:**
+
+- fix corner case in `collapse\_vars` [\#3139](https://github.com/mishoo/UglifyJS2/pull/3139) ([alexlamsl](https://github.com/alexlamsl))
+- Update README.md to clarify --source-map filename option [\#3137](https://github.com/mishoo/UglifyJS2/pull/3137) ([exvisory](https://github.com/exvisory))
+
+## [v3.3.25](https://github.com/mishoo/UglifyJS2/tree/v3.3.25) (2018-05-12)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.24...v3.3.25)
+
+**Merged pull requests:**
+
+- remove `colors` dependency [\#3133](https://github.com/mishoo/UglifyJS2/pull/3133) ([alexlamsl](https://github.com/alexlamsl))
+- replace `mocha` dependency [\#3131](https://github.com/mishoo/UglifyJS2/pull/3131) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `reduce\_vars` [\#3129](https://github.com/mishoo/UglifyJS2/pull/3129) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in call binding [\#3128](https://github.com/mishoo/UglifyJS2/pull/3128) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.24](https://github.com/mishoo/UglifyJS2/tree/v3.3.24) (2018-05-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.23...v3.3.24)
+
+**Merged pull requests:**
+
+- fix various corner cases [\#3126](https://github.com/mishoo/UglifyJS2/pull/3126) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `reduce\_vars` [\#3124](https://github.com/mishoo/UglifyJS2/pull/3124) ([alexlamsl](https://github.com/alexlamsl))
+- fix various corner cases [\#3123](https://github.com/mishoo/UglifyJS2/pull/3123) ([alexlamsl](https://github.com/alexlamsl))
+- speed up `collapse\_vars` [\#3119](https://github.com/mishoo/UglifyJS2/pull/3119) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on nested invocations [\#3118](https://github.com/mishoo/UglifyJS2/pull/3118) ([alexlamsl](https://github.com/alexlamsl))
+- compress `AST\_Sequence` within `AST\_Call` [\#3117](https://github.com/mishoo/UglifyJS2/pull/3117) ([alexlamsl](https://github.com/alexlamsl))
+- better fix for \#3113 [\#3115](https://github.com/mishoo/UglifyJS2/pull/3115) ([alexlamsl](https://github.com/alexlamsl))
+- fix `TreeWalker` scan order [\#3114](https://github.com/mishoo/UglifyJS2/pull/3114) ([alexlamsl](https://github.com/alexlamsl))
+- improve `reduce\_vars` [\#3112](https://github.com/mishoo/UglifyJS2/pull/3112) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.23](https://github.com/mishoo/UglifyJS2/tree/v3.3.23) (2018-04-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.22...v3.3.23)
+
+**Merged pull requests:**
+
+- improve numeral compression [\#3108](https://github.com/mishoo/UglifyJS2/pull/3108) ([alexlamsl](https://github.com/alexlamsl))
+- workaround `vm` context issue in `node-chakracore` [\#3106](https://github.com/mishoo/UglifyJS2/pull/3106) ([alexlamsl](https://github.com/alexlamsl))
+- improve general performance [\#3104](https://github.com/mishoo/UglifyJS2/pull/3104) ([alexlamsl](https://github.com/alexlamsl))
+- improve `collapse\_vars` [\#3103](https://github.com/mishoo/UglifyJS2/pull/3103) ([alexlamsl](https://github.com/alexlamsl))
+- workaround test failures on Node.js 10 [\#3102](https://github.com/mishoo/UglifyJS2/pull/3102) ([alexlamsl](https://github.com/alexlamsl))
+- workaround stack overflow in ChakraCore [\#3101](https://github.com/mishoo/UglifyJS2/pull/3101) ([alexlamsl](https://github.com/alexlamsl))
+- better fix for \#2506 [\#3099](https://github.com/mishoo/UglifyJS2/pull/3099) ([alexlamsl](https://github.com/alexlamsl))
+- handle RHS side-effects in `collapse\_vars` [\#3097](https://github.com/mishoo/UglifyJS2/pull/3097) ([alexlamsl](https://github.com/alexlamsl))
+- improve `max\_line\_len` [\#3095](https://github.com/mishoo/UglifyJS2/pull/3095) ([alexlamsl](https://github.com/alexlamsl))
+- update `AST` documentation [\#3094](https://github.com/mishoo/UglifyJS2/pull/3094) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.22](https://github.com/mishoo/UglifyJS2/tree/v3.3.22) (2018-04-20)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.21...v3.3.22)
+
+**Merged pull requests:**
+
+- fix corner case in `strip\_func\_ids\(\)` [\#3090](https://github.com/mishoo/UglifyJS2/pull/3090) ([alexlamsl](https://github.com/alexlamsl))
+- improve performance when handling unused variables in `collapse\_vars` [\#3084](https://github.com/mishoo/UglifyJS2/pull/3084) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.21](https://github.com/mishoo/UglifyJS2/tree/v3.3.21) (2018-04-12)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.20...v3.3.21)
+
+**Merged pull requests:**
+
+- fix `inline` of `catch`-scoped variables [\#3077](https://github.com/mishoo/UglifyJS2/pull/3077) ([alexlamsl](https://github.com/alexlamsl))
+- suppress `hoist\_props` for embedded assignments [\#3074](https://github.com/mishoo/UglifyJS2/pull/3074) ([alexlamsl](https://github.com/alexlamsl))
+- extend `hoist\_props` [\#3073](https://github.com/mishoo/UglifyJS2/pull/3073) ([alexlamsl](https://github.com/alexlamsl))
+- extend `join\_vars` on object assignments [\#3072](https://github.com/mishoo/UglifyJS2/pull/3072) ([alexlamsl](https://github.com/alexlamsl))
+- handle flow control in loops with `reduce\_vars` [\#3069](https://github.com/mishoo/UglifyJS2/pull/3069) ([alexlamsl](https://github.com/alexlamsl))
+- handle `pure\_funcs` under `inline` & `reduce\_vars` correctly [\#3066](https://github.com/mishoo/UglifyJS2/pull/3066) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.20](https://github.com/mishoo/UglifyJS2/tree/v3.3.20) (2018-04-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.19...v3.3.20)
+
+**Merged pull requests:**
+
+- fix corner case in reuse of `mangle` options [\#3062](https://github.com/mishoo/UglifyJS2/pull/3062) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.19](https://github.com/mishoo/UglifyJS2/tree/v3.3.19) (2018-04-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.18...v3.3.19)
+
+**Merged pull requests:**
+
+- mangle `Object.defineProperty\(\)` [\#3059](https://github.com/mishoo/UglifyJS2/pull/3059) ([alexlamsl](https://github.com/alexlamsl))
+- support inline source map from multiple files [\#3058](https://github.com/mishoo/UglifyJS2/pull/3058) ([alexlamsl](https://github.com/alexlamsl))
+- improve usability of `includeSources` [\#3057](https://github.com/mishoo/UglifyJS2/pull/3057) ([alexlamsl](https://github.com/alexlamsl))
+- fix AST corruption during `inline` of simple `return` [\#3056](https://github.com/mishoo/UglifyJS2/pull/3056) ([alexlamsl](https://github.com/alexlamsl))
+- speed up `has\_parens\(\)` \(take 2\) [\#3052](https://github.com/mishoo/UglifyJS2/pull/3052) ([alexlamsl](https://github.com/alexlamsl))
+- improve performance through `makePredicate\(\)` [\#3048](https://github.com/mishoo/UglifyJS2/pull/3048) ([alexlamsl](https://github.com/alexlamsl))
+- fix tree traversal on `AST\_Do` [\#3047](https://github.com/mishoo/UglifyJS2/pull/3047) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.18](https://github.com/mishoo/UglifyJS2/tree/v3.3.18) (2018-04-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.17...v3.3.18)
+
+**Merged pull requests:**
+
+- give sensible error against invalid input source map [\#3044](https://github.com/mishoo/UglifyJS2/pull/3044) ([alexlamsl](https://github.com/alexlamsl))
+- fix escape analysis on `AST\_New` [\#3043](https://github.com/mishoo/UglifyJS2/pull/3043) ([alexlamsl](https://github.com/alexlamsl))
+- Don't load source map until the JS source is fully received [\#3040](https://github.com/mishoo/UglifyJS2/pull/3040) ([b-fuze](https://github.com/b-fuze))
+
+## [v3.3.17](https://github.com/mishoo/UglifyJS2/tree/v3.3.17) (2018-03-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.16...v3.3.17)
+
+**Merged pull requests:**
+
+- mangle unused nested `AST\_SymbolCatch` correctly [\#3038](https://github.com/mishoo/UglifyJS2/pull/3038) ([alexlamsl](https://github.com/alexlamsl))
+- handle modifications to `this` correctly [\#3036](https://github.com/mishoo/UglifyJS2/pull/3036) ([alexlamsl](https://github.com/alexlamsl))
+- improve test for \#3023 [\#3031](https://github.com/mishoo/UglifyJS2/pull/3031) ([alexlamsl](https://github.com/alexlamsl))
+- improve source map granularity [\#3030](https://github.com/mishoo/UglifyJS2/pull/3030) ([alexlamsl](https://github.com/alexlamsl))
+- fix extra regex slash when going through mozilla AST I/O [\#3025](https://github.com/mishoo/UglifyJS2/pull/3025) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- fix corner case in `hoist\_props` [\#3022](https://github.com/mishoo/UglifyJS2/pull/3022) ([alexlamsl](https://github.com/alexlamsl))
+- improve performance [\#3020](https://github.com/mishoo/UglifyJS2/pull/3020) ([alexlamsl](https://github.com/alexlamsl))
+- fix nested `inline` within loop [\#3019](https://github.com/mishoo/UglifyJS2/pull/3019) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `inline` [\#3017](https://github.com/mishoo/UglifyJS2/pull/3017) ([alexlamsl](https://github.com/alexlamsl))
+- speed up `has\_parens\(\)` [\#3014](https://github.com/mishoo/UglifyJS2/pull/3014) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.16](https://github.com/mishoo/UglifyJS2/tree/v3.3.16) (2018-03-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.15...v3.3.16)
+
+**Merged pull requests:**
+
+- improve truthy compression [\#3009](https://github.com/mishoo/UglifyJS2/pull/3009) ([alexlamsl](https://github.com/alexlamsl))
+- extend fuzzy RHS folding [\#3006](https://github.com/mishoo/UglifyJS2/pull/3006) ([alexlamsl](https://github.com/alexlamsl))
+- refactor brackets to braces [\#3005](https://github.com/mishoo/UglifyJS2/pull/3005) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.15](https://github.com/mishoo/UglifyJS2/tree/v3.3.15) (2018-03-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.14...v3.3.15)
+
+**Merged pull requests:**
+
+- update dependencies [\#3002](https://github.com/mishoo/UglifyJS2/pull/3002) ([alexlamsl](https://github.com/alexlamsl))
+- retain comments within brackets [\#2999](https://github.com/mishoo/UglifyJS2/pull/2999) ([alexlamsl](https://github.com/alexlamsl))
+- preserve non-constant value assignments with modifications [\#2997](https://github.com/mishoo/UglifyJS2/pull/2997) ([alexlamsl](https://github.com/alexlamsl))
+- handle `case` correctly under `reduce\_vars` [\#2993](https://github.com/mishoo/UglifyJS2/pull/2993) ([alexlamsl](https://github.com/alexlamsl))
+- preserve case when `inline\_script` [\#2991](https://github.com/mishoo/UglifyJS2/pull/2991) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.14](https://github.com/mishoo/UglifyJS2/tree/v3.3.14) (2018-03-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.13...v3.3.14)
+
+**Merged pull requests:**
+
+- fix `mangle` of `AST\_SymbolLambda` under `ie8` [\#2978](https://github.com/mishoo/UglifyJS2/pull/2978) ([alexlamsl](https://github.com/alexlamsl))
+- handle negated constants correctly in `collapse\_vars` [\#2975](https://github.com/mishoo/UglifyJS2/pull/2975) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.13](https://github.com/mishoo/UglifyJS2/tree/v3.3.13) (2018-03-04)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.12...v3.3.13)
+
+**Merged pull requests:**
+
+- improve `test/run-test.js` performance [\#2971](https://github.com/mishoo/UglifyJS2/pull/2971) ([alexlamsl](https://github.com/alexlamsl))
+- fix value reference caching in `evaluate` [\#2969](https://github.com/mishoo/UglifyJS2/pull/2969) ([alexlamsl](https://github.com/alexlamsl))
+- compress `arguments\[index\]` [\#2967](https://github.com/mishoo/UglifyJS2/pull/2967) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `conditionals` [\#2966](https://github.com/mishoo/UglifyJS2/pull/2966) ([alexlamsl](https://github.com/alexlamsl))
+- drop `side\_effects`-free `return` values [\#2965](https://github.com/mishoo/UglifyJS2/pull/2965) ([alexlamsl](https://github.com/alexlamsl))
+- drop lone "use strict" in function body [\#2963](https://github.com/mishoo/UglifyJS2/pull/2963) ([alexlamsl](https://github.com/alexlamsl))
+- migrate safe transformations out of `unsafe\_comps` [\#2962](https://github.com/mishoo/UglifyJS2/pull/2962) ([alexlamsl](https://github.com/alexlamsl))
+- show benchmark subtotal [\#2960](https://github.com/mishoo/UglifyJS2/pull/2960) ([Skalman](https://github.com/Skalman))
+- improve fix for \#2954 [\#2958](https://github.com/mishoo/UglifyJS2/pull/2958) ([alexlamsl](https://github.com/alexlamsl))
+- fix `collapse\_vars` on nested exception [\#2955](https://github.com/mishoo/UglifyJS2/pull/2955) ([alexlamsl](https://github.com/alexlamsl))
+- deduplicate parenthesis around object and function literals [\#2953](https://github.com/mishoo/UglifyJS2/pull/2953) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `collapse\_vars` [\#2952](https://github.com/mishoo/UglifyJS2/pull/2952) ([alexlamsl](https://github.com/alexlamsl))
+- minor clean-ups [\#2951](https://github.com/mishoo/UglifyJS2/pull/2951) ([alexlamsl](https://github.com/alexlamsl))
+- improve `mangle` [\#2948](https://github.com/mishoo/UglifyJS2/pull/2948) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.12](https://github.com/mishoo/UglifyJS2/tree/v3.3.12) (2018-02-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.11...v3.3.12)
+
+**Merged pull requests:**
+
+- more tests for \#2938 [\#2940](https://github.com/mishoo/UglifyJS2/pull/2940) ([alexlamsl](https://github.com/alexlamsl))
+- workaround `pure\_getters=true` when dropping unused assignments [\#2939](https://github.com/mishoo/UglifyJS2/pull/2939) ([alexlamsl](https://github.com/alexlamsl))
+- improve `unsafe` `evaluate` of `function` [\#2936](https://github.com/mishoo/UglifyJS2/pull/2936) ([alexlamsl](https://github.com/alexlamsl))
+- reduce false positives from object literals [\#2935](https://github.com/mishoo/UglifyJS2/pull/2935) ([alexlamsl](https://github.com/alexlamsl))
+- reduce false positives from labels [\#2934](https://github.com/mishoo/UglifyJS2/pull/2934) ([alexlamsl](https://github.com/alexlamsl))
+- reduce false positives from noop [\#2933](https://github.com/mishoo/UglifyJS2/pull/2933) ([alexlamsl](https://github.com/alexlamsl))
+- fix crash in `may\_throw\(\)` [\#2932](https://github.com/mishoo/UglifyJS2/pull/2932) ([alexlamsl](https://github.com/alexlamsl))
+- fix `dead\_code` on exceptional `return` [\#2930](https://github.com/mishoo/UglifyJS2/pull/2930) ([alexlamsl](https://github.com/alexlamsl))
+- reduce false positives from `function.toString\(\)` [\#2928](https://github.com/mishoo/UglifyJS2/pull/2928) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` `evaluate` of `function` property [\#2927](https://github.com/mishoo/UglifyJS2/pull/2927) ([alexlamsl](https://github.com/alexlamsl))
+- reduce `function`-related false positives [\#2925](https://github.com/mishoo/UglifyJS2/pull/2925) ([alexlamsl](https://github.com/alexlamsl))
+- improve `inline` efficiency [\#2924](https://github.com/mishoo/UglifyJS2/pull/2924) ([alexlamsl](https://github.com/alexlamsl))
+- drop unused "class" definition IIFEs [\#2923](https://github.com/mishoo/UglifyJS2/pull/2923) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` `evaluate` of `AST\_Function` [\#2920](https://github.com/mishoo/UglifyJS2/pull/2920) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.11](https://github.com/mishoo/UglifyJS2/tree/v3.3.11) (2018-02-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.10...v3.3.11)
+
+**Merged pull requests:**
+
+- fix `unsafe` `evaluate` on type-converting operators [\#2917](https://github.com/mishoo/UglifyJS2/pull/2917) ([alexlamsl](https://github.com/alexlamsl))
+- fix `collapse\_vars` within loops [\#2915](https://github.com/mishoo/UglifyJS2/pull/2915) ([alexlamsl](https://github.com/alexlamsl))
+- report options upon reminify input error [\#2911](https://github.com/mishoo/UglifyJS2/pull/2911) ([alexlamsl](https://github.com/alexlamsl))
+- collapse within unary expressions [\#2910](https://github.com/mishoo/UglifyJS2/pull/2910) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `collapse\_vars` [\#2909](https://github.com/mishoo/UglifyJS2/pull/2909) ([alexlamsl](https://github.com/alexlamsl))
+- simplify `do-while` into `for` [\#2907](https://github.com/mishoo/UglifyJS2/pull/2907) ([alexlamsl](https://github.com/alexlamsl))
+- fix AST corruption due to `collapse\_vars` & `inline` [\#2899](https://github.com/mishoo/UglifyJS2/pull/2899) ([alexlamsl](https://github.com/alexlamsl))
+- fix `collapse\_vars` regression in destructuring [\#2897](https://github.com/mishoo/UglifyJS2/pull/2897) ([kzc](https://github.com/kzc))
+- fix `join\_vars` on property accessors [\#2895](https://github.com/mishoo/UglifyJS2/pull/2895) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.10](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.10) (2018-02-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.10...harmony-v3.3.10)
+
+**Merged pull requests:**
+
+- Harmony v3.3.10 [\#2894](https://github.com/mishoo/UglifyJS2/pull/2894) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.10](https://github.com/mishoo/UglifyJS2/tree/v3.3.10) (2018-02-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.9...v3.3.10)
+
+**Merged pull requests:**
+
+- account for exceptions in `AST\_Assign.left` [\#2892](https://github.com/mishoo/UglifyJS2/pull/2892) ([alexlamsl](https://github.com/alexlamsl))
+- update dependencies [\#2889](https://github.com/mishoo/UglifyJS2/pull/2889) ([alexlamsl](https://github.com/alexlamsl))
+- mention file encoding [\#2887](https://github.com/mishoo/UglifyJS2/pull/2887) ([alexlamsl](https://github.com/alexlamsl))
+- evaluate `to{Low,Upp}erCase\(\)` under `unsafe` [\#2886](https://github.com/mishoo/UglifyJS2/pull/2886) ([alexlamsl](https://github.com/alexlamsl))
+- add information on testing and code style [\#2885](https://github.com/mishoo/UglifyJS2/pull/2885) ([Skalman](https://github.com/Skalman))
+- describe a few compiler assumptions [\#2883](https://github.com/mishoo/UglifyJS2/pull/2883) ([Skalman](https://github.com/Skalman))
+- change `undefined == x` to `null == x` [\#2882](https://github.com/mishoo/UglifyJS2/pull/2882) ([Skalman](https://github.com/Skalman))
+- fix `inline` within arrow functions [\#2881](https://github.com/mishoo/UglifyJS2/pull/2881) ([kzc](https://github.com/kzc))
+- improve exceptional flow compression by `collapse\_vars` [\#2880](https://github.com/mishoo/UglifyJS2/pull/2880) ([alexlamsl](https://github.com/alexlamsl))
+- maintain order between side-effects and externally observable assignments [\#2879](https://github.com/mishoo/UglifyJS2/pull/2879) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `arguments` in arrow functions [\#2877](https://github.com/mishoo/UglifyJS2/pull/2877) ([kzc](https://github.com/kzc))
+- handle `break` & `continue` in `collapse\_vars` [\#2875](https://github.com/mishoo/UglifyJS2/pull/2875) ([alexlamsl](https://github.com/alexlamsl))
+- fix assignment logic in `reduce\_vars` [\#2872](https://github.com/mishoo/UglifyJS2/pull/2872) ([alexlamsl](https://github.com/alexlamsl))
+- fix missing corner case in \#2855 [\#2868](https://github.com/mishoo/UglifyJS2/pull/2868) ([alexlamsl](https://github.com/alexlamsl))
+- allow `collapse\_vars` across conditional branches [\#2867](https://github.com/mishoo/UglifyJS2/pull/2867) ([alexlamsl](https://github.com/alexlamsl))
+- Update License Copyright Year to 2018 [\#2866](https://github.com/mishoo/UglifyJS2/pull/2866) ([Icidis](https://github.com/Icidis))
+- always test for `rename` [\#2865](https://github.com/mishoo/UglifyJS2/pull/2865) ([alexlamsl](https://github.com/alexlamsl))
+- better fix for \#2858 [\#2864](https://github.com/mishoo/UglifyJS2/pull/2864) ([alexlamsl](https://github.com/alexlamsl))
+- account for side-effects in `comparisons` of `null` & `undefined` [\#2863](https://github.com/mishoo/UglifyJS2/pull/2863) ([alexlamsl](https://github.com/alexlamsl))
+- simplify comparisons with `undefined` & `null` [\#2862](https://github.com/mishoo/UglifyJS2/pull/2862) ([alexlamsl](https://github.com/alexlamsl))
+- avoid `evaluate` of compound assignment after `dead\_code` transform [\#2861](https://github.com/mishoo/UglifyJS2/pull/2861) ([alexlamsl](https://github.com/alexlamsl))
+- account for declaration assignment in `collapse\_vars` [\#2859](https://github.com/mishoo/UglifyJS2/pull/2859) ([alexlamsl](https://github.com/alexlamsl))
+- relax `collapse\_vars` on `AST\_Exit` [\#2855](https://github.com/mishoo/UglifyJS2/pull/2855) ([alexlamsl](https://github.com/alexlamsl))
+- improve symbol replacement heuristic [\#2851](https://github.com/mishoo/UglifyJS2/pull/2851) ([alexlamsl](https://github.com/alexlamsl))
+- compress chained compound assignments [\#2850](https://github.com/mishoo/UglifyJS2/pull/2850) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.9](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.9) (2018-01-27)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.9...harmony-v3.3.9)
+
+**Merged pull requests:**
+
+- Harmony v3.3.9 [\#2848](https://github.com/mishoo/UglifyJS2/pull/2848) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.9](https://github.com/mishoo/UglifyJS2/tree/v3.3.9) (2018-01-27)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.8...v3.3.9)
+
+**Merged pull requests:**
+
+- fix accounting after conversion to assignment [\#2847](https://github.com/mishoo/UglifyJS2/pull/2847) ([alexlamsl](https://github.com/alexlamsl))
+- backport of \#2840 [\#2841](https://github.com/mishoo/UglifyJS2/pull/2841) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix for-in/of regression with let or const loop variable [\#2840](https://github.com/mishoo/UglifyJS2/pull/2840) ([kzc](https://github.com/kzc))
+- drop assignments to constant expressions only [\#2839](https://github.com/mishoo/UglifyJS2/pull/2839) ([alexlamsl](https://github.com/alexlamsl))
+- handle duplicate function declarations correctly [\#2837](https://github.com/mishoo/UglifyJS2/pull/2837) ([alexlamsl](https://github.com/alexlamsl))
+- enable reminify on harmony branch to avoid regressions [\#2834](https://github.com/mishoo/UglifyJS2/pull/2834) ([kzc](https://github.com/kzc))
+- \[ES6\] add parenthesis around sequence in `yield` [\#2833](https://github.com/mishoo/UglifyJS2/pull/2833) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.8](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.8) (2018-01-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.8...harmony-v3.3.8)
+
+**Merged pull requests:**
+
+- Harmony v3.3.8 [\#2829](https://github.com/mishoo/UglifyJS2/pull/2829) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.8](https://github.com/mishoo/UglifyJS2/tree/v3.3.8) (2018-01-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.7...v3.3.8)
+
+**Merged pull requests:**
+
+- fix `unsafe` `evaluate` of `AST\_Array` [\#2825](https://github.com/mishoo/UglifyJS2/pull/2825) ([alexlamsl](https://github.com/alexlamsl))
+- enable `unsafe` for `test/ufuzz.js` [\#2819](https://github.com/mishoo/UglifyJS2/pull/2819) ([alexlamsl](https://github.com/alexlamsl))
+- avoid duplicate property names in object literals under "use strict" [\#2818](https://github.com/mishoo/UglifyJS2/pull/2818) ([alexlamsl](https://github.com/alexlamsl))
+- improve `unused` on built-in functions [\#2817](https://github.com/mishoo/UglifyJS2/pull/2817) ([alexlamsl](https://github.com/alexlamsl))
+- fix & improve `test/ufuzz.js` [\#2815](https://github.com/mishoo/UglifyJS2/pull/2815) ([alexlamsl](https://github.com/alexlamsl))
+- fix time-out for respawned `test/ufuzz.js` [\#2814](https://github.com/mishoo/UglifyJS2/pull/2814) ([alexlamsl](https://github.com/alexlamsl))
+- compress `undefined` property names [\#2811](https://github.com/mishoo/UglifyJS2/pull/2811) ([alexlamsl](https://github.com/alexlamsl))
+- fix `join\_vars` property assignment for negative array index [\#2810](https://github.com/mishoo/UglifyJS2/pull/2810) ([kzc](https://github.com/kzc))
+- enhance `test/ufuzz.js` [\#2808](https://github.com/mishoo/UglifyJS2/pull/2808) ([alexlamsl](https://github.com/alexlamsl))
+- faster output of comments [\#2806](https://github.com/mishoo/UglifyJS2/pull/2806) ([alexlamsl](https://github.com/alexlamsl))
+- suppress `unsafe\_proto` for LHS expressions [\#2804](https://github.com/mishoo/UglifyJS2/pull/2804) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_Scope.clone\(\)` [\#2803](https://github.com/mishoo/UglifyJS2/pull/2803) ([alexlamsl](https://github.com/alexlamsl))
+- configure `rename` with CLI [\#2802](https://github.com/mishoo/UglifyJS2/pull/2802) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix various for-of bugs [\#2800](https://github.com/mishoo/UglifyJS2/pull/2800) ([kzc](https://github.com/kzc))
+- extend `join\_vars` & `sequences` [\#2798](https://github.com/mishoo/UglifyJS2/pull/2798) ([alexlamsl](https://github.com/alexlamsl))
+- improve `mocha` tests [\#2797](https://github.com/mishoo/UglifyJS2/pull/2797) ([alexlamsl](https://github.com/alexlamsl))
+- general improvements around `AST\_ForIn` [\#2796](https://github.com/mishoo/UglifyJS2/pull/2796) ([alexlamsl](https://github.com/alexlamsl))
+- improve `test/travis-ufuzz.js` [\#2795](https://github.com/mishoo/UglifyJS2/pull/2795) ([alexlamsl](https://github.com/alexlamsl))
+- Fix typo in README [\#2792](https://github.com/mishoo/UglifyJS2/pull/2792) ([Jolg42](https://github.com/Jolg42))
+- handle VM failure gracefully [\#2791](https://github.com/mishoo/UglifyJS2/pull/2791) ([alexlamsl](https://github.com/alexlamsl))
+- improve `test/travis-ufuzz.js` [\#2789](https://github.com/mishoo/UglifyJS2/pull/2789) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `collapse\_vars` [\#2788](https://github.com/mishoo/UglifyJS2/pull/2788) ([alexlamsl](https://github.com/alexlamsl))
+- avoid suboptimal termination in `passes` [\#2787](https://github.com/mishoo/UglifyJS2/pull/2787) ([alexlamsl](https://github.com/alexlamsl))
+- improve `test/travis-ufuzz.js` [\#2786](https://github.com/mishoo/UglifyJS2/pull/2786) ([alexlamsl](https://github.com/alexlamsl))
+- avoid double counting within single-use functions [\#2785](https://github.com/mishoo/UglifyJS2/pull/2785) ([alexlamsl](https://github.com/alexlamsl))
+- run `test/ufuzz.js` when Travis CI is idle [\#2784](https://github.com/mishoo/UglifyJS2/pull/2784) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.7](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.7) (2018-01-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.7...harmony-v3.3.7)
+
+**Merged pull requests:**
+
+- Harmony v3.3.7 [\#2782](https://github.com/mishoo/UglifyJS2/pull/2782) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.7](https://github.com/mishoo/UglifyJS2/tree/v3.3.7) (2018-01-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.6...v3.3.7)
+
+**Merged pull requests:**
+
+- fix & extend `join\_vars` for object assigments [\#2781](https://github.com/mishoo/UglifyJS2/pull/2781) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] add `block\_scope` to `--output ast` [\#2780](https://github.com/mishoo/UglifyJS2/pull/2780) ([kzc](https://github.com/kzc))
+- fix `mangle` of block-scoped variables [\#2779](https://github.com/mishoo/UglifyJS2/pull/2779) ([alexlamsl](https://github.com/alexlamsl))
+- improve SymbolDef info in `--output ast` [\#2778](https://github.com/mishoo/UglifyJS2/pull/2778) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.3.6](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.6) (2018-01-13)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.6...harmony-v3.3.6)
+
+**Merged pull requests:**
+
+- Harmony v3.3.6 [\#2777](https://github.com/mishoo/UglifyJS2/pull/2777) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.6](https://github.com/mishoo/UglifyJS2/tree/v3.3.6) (2018-01-13)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.5...v3.3.6)
+
+**Merged pull requests:**
+
+- fix `reduce\_vars` on `AST\_Accessor` [\#2776](https://github.com/mishoo/UglifyJS2/pull/2776) ([alexlamsl](https://github.com/alexlamsl))
+- add SymbolDef IDs to `--output ast` [\#2772](https://github.com/mishoo/UglifyJS2/pull/2772) ([kzc](https://github.com/kzc))
+- fix output of imported AST [\#2771](https://github.com/mishoo/UglifyJS2/pull/2771) ([alexlamsl](https://github.com/alexlamsl))
+- update dependencies [\#2770](https://github.com/mishoo/UglifyJS2/pull/2770) ([alexlamsl](https://github.com/alexlamsl))
+- fix nested `unused` assignments [\#2769](https://github.com/mishoo/UglifyJS2/pull/2769) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in \#2763 [\#2766](https://github.com/mishoo/UglifyJS2/pull/2766) ([alexlamsl](https://github.com/alexlamsl))
+- join object assignments [\#2763](https://github.com/mishoo/UglifyJS2/pull/2763) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` with uninitialized `let` variables [\#2760](https://github.com/mishoo/UglifyJS2/pull/2760) ([alexlamsl](https://github.com/alexlamsl))
+- skip only `var`s in `if\_return` [\#2759](https://github.com/mishoo/UglifyJS2/pull/2759) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `conditionals` [\#2758](https://github.com/mishoo/UglifyJS2/pull/2758) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] trap `const` declaration without value in parse [\#2756](https://github.com/mishoo/UglifyJS2/pull/2756) ([kzc](https://github.com/kzc))
+- improve synergy between `compress` and `rename` [\#2755](https://github.com/mishoo/UglifyJS2/pull/2755) ([alexlamsl](https://github.com/alexlamsl))
+- improve `rename` reproducibility [\#2754](https://github.com/mishoo/UglifyJS2/pull/2754) ([alexlamsl](https://github.com/alexlamsl))
+- patch variable declaractions extracted within `catch` [\#2753](https://github.com/mishoo/UglifyJS2/pull/2753) ([alexlamsl](https://github.com/alexlamsl))
+- compress loops with immediate `break` [\#2746](https://github.com/mishoo/UglifyJS2/pull/2746) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.5](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.5) (2018-01-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.5...harmony-v3.3.5)
+
+**Merged pull requests:**
+
+- Harmony v3.3.5 [\#2742](https://github.com/mishoo/UglifyJS2/pull/2742) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.5](https://github.com/mishoo/UglifyJS2/tree/v3.3.5) (2018-01-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.4...v3.3.5)
+
+**Merged pull requests:**
+
+- improve `process.exit\(\)` workaround [\#2741](https://github.com/mishoo/UglifyJS2/pull/2741) ([alexlamsl](https://github.com/alexlamsl))
+- enable AppVeyor CI [\#2739](https://github.com/mishoo/UglifyJS2/pull/2739) ([alexlamsl](https://github.com/alexlamsl))
+- fix recursive function `inline` [\#2738](https://github.com/mishoo/UglifyJS2/pull/2738) ([alexlamsl](https://github.com/alexlamsl))
+- handle trailing line comments correctly [\#2736](https://github.com/mishoo/UglifyJS2/pull/2736) ([alexlamsl](https://github.com/alexlamsl))
+- compress `RegExp\(\)` in `unsafe` [\#2735](https://github.com/mishoo/UglifyJS2/pull/2735) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `unsafe\_proto` [\#2733](https://github.com/mishoo/UglifyJS2/pull/2733) ([alexlamsl](https://github.com/alexlamsl))
+- ufuzz: add strings "a", "b", "c" to VALUES [\#2732](https://github.com/mishoo/UglifyJS2/pull/2732) ([kzc](https://github.com/kzc))
+- fix corner case with `arguments` as function name [\#2729](https://github.com/mishoo/UglifyJS2/pull/2729) ([alexlamsl](https://github.com/alexlamsl))
+- improve `if\_return` [\#2727](https://github.com/mishoo/UglifyJS2/pull/2727) ([alexlamsl](https://github.com/alexlamsl))
+- warn on deprecated features [\#2726](https://github.com/mishoo/UglifyJS2/pull/2726) ([alexlamsl](https://github.com/alexlamsl))
+- fix `hoist\_props` on `const` [\#2724](https://github.com/mishoo/UglifyJS2/pull/2724) ([alexlamsl](https://github.com/alexlamsl))
+- fix `mangle` name collision across files [\#2722](https://github.com/mishoo/UglifyJS2/pull/2722) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `inline` [\#2720](https://github.com/mishoo/UglifyJS2/pull/2720) ([alexlamsl](https://github.com/alexlamsl))
+- forbid block-scoped `AST\_Defun` in strict mode [\#2718](https://github.com/mishoo/UglifyJS2/pull/2718) ([alexlamsl](https://github.com/alexlamsl))
+- preserve constant modification under strict mode [\#2717](https://github.com/mishoo/UglifyJS2/pull/2717) ([alexlamsl](https://github.com/alexlamsl))
+- reminify tests upon `expect\_stdout` [\#2716](https://github.com/mishoo/UglifyJS2/pull/2716) ([alexlamsl](https://github.com/alexlamsl))
+- extend `inline` [\#2714](https://github.com/mishoo/UglifyJS2/pull/2714) ([alexlamsl](https://github.com/alexlamsl))
+- apply `collapse\_vars` to loop conditions [\#2712](https://github.com/mishoo/UglifyJS2/pull/2712) ([alexlamsl](https://github.com/alexlamsl))
+- drop `unused` assignment based on `reduce\_vars` [\#2709](https://github.com/mishoo/UglifyJS2/pull/2709) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on `AST\_Defun` [\#2708](https://github.com/mishoo/UglifyJS2/pull/2708) ([alexlamsl](https://github.com/alexlamsl))
+- extend `\_\_PURE\_\_` to `AST\_New` [\#2706](https://github.com/mishoo/UglifyJS2/pull/2706) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `collapse\_vars` [\#2704](https://github.com/mishoo/UglifyJS2/pull/2704) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `if\_return` [\#2703](https://github.com/mishoo/UglifyJS2/pull/2703) ([alexlamsl](https://github.com/alexlamsl))
+- scan within IIFEs of assigned values [\#2702](https://github.com/mishoo/UglifyJS2/pull/2702) ([alexlamsl](https://github.com/alexlamsl))
+- mark `AST\_Var` out of block scopes [\#2700](https://github.com/mishoo/UglifyJS2/pull/2700) ([alexlamsl](https://github.com/alexlamsl))
+- reset argument value within loop after `inline` [\#2699](https://github.com/mishoo/UglifyJS2/pull/2699) ([alexlamsl](https://github.com/alexlamsl))
+- fix `inline` on duplicate argument names [\#2698](https://github.com/mishoo/UglifyJS2/pull/2698) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `join\_vars` & `sequences` [\#2697](https://github.com/mishoo/UglifyJS2/pull/2697) ([alexlamsl](https://github.com/alexlamsl))
+- inline functions with `AST\_Var` [\#2688](https://github.com/mishoo/UglifyJS2/pull/2688) ([alexlamsl](https://github.com/alexlamsl))
+- reduce hoisting declarations [\#2687](https://github.com/mishoo/UglifyJS2/pull/2687) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.4](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.4) (2017-12-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.4...harmony-v3.3.4)
+
+**Merged pull requests:**
+
+- Harmony v3.3.4 [\#2695](https://github.com/mishoo/UglifyJS2/pull/2695) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.4](https://github.com/mishoo/UglifyJS2/tree/v3.3.4) (2017-12-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.3...v3.3.4)
+
+**Merged pull requests:**
+
+- improve test for \#2689 [\#2694](https://github.com/mishoo/UglifyJS2/pull/2694) ([alexlamsl](https://github.com/alexlamsl))
+- fix `dead\_code` on escaped `return` assignment [\#2693](https://github.com/mishoo/UglifyJS2/pull/2693) ([alexlamsl](https://github.com/alexlamsl))
+- fix parse and output of `yield` [\#2690](https://github.com/mishoo/UglifyJS2/pull/2690) ([alexlamsl](https://github.com/alexlamsl))
+- minor clean-ups [\#2686](https://github.com/mishoo/UglifyJS2/pull/2686) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.3](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.3) (2017-12-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.3...harmony-v3.3.3)
+
+**Merged pull requests:**
+
+- Harmony v3.3.3 [\#2684](https://github.com/mishoo/UglifyJS2/pull/2684) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.3](https://github.com/mishoo/UglifyJS2/tree/v3.3.3) (2017-12-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.2...v3.3.3)
+
+**Merged pull requests:**
+
+- fix `pure\_getters` on `AST\_Binary` [\#2681](https://github.com/mishoo/UglifyJS2/pull/2681) ([alexlamsl](https://github.com/alexlamsl))
+- fix parenthesis output of `AST\_ClassExpression` [\#2677](https://github.com/mishoo/UglifyJS2/pull/2677) ([alexlamsl](https://github.com/alexlamsl))
+- fix function inlining within loops [\#2675](https://github.com/mishoo/UglifyJS2/pull/2675) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on `AST\_Destructuring` [\#2672](https://github.com/mishoo/UglifyJS2/pull/2672) ([alexlamsl](https://github.com/alexlamsl))
+- improve assignment variations [\#2671](https://github.com/mishoo/UglifyJS2/pull/2671) ([alexlamsl](https://github.com/alexlamsl))
+- fix `dead\_code` on `return` assignments [\#2668](https://github.com/mishoo/UglifyJS2/pull/2668) ([alexlamsl](https://github.com/alexlamsl))
+- retain recursive function names [\#2667](https://github.com/mishoo/UglifyJS2/pull/2667) ([alexlamsl](https://github.com/alexlamsl))
+- fix bugs on substituted `AST\_Defun` [\#2661](https://github.com/mishoo/UglifyJS2/pull/2661) ([alexlamsl](https://github.com/alexlamsl))
+- replace single-use recursive functions [\#2659](https://github.com/mishoo/UglifyJS2/pull/2659) ([alexlamsl](https://github.com/alexlamsl))
+- suppress `inline` within substituted `AST\_Scope` [\#2658](https://github.com/mishoo/UglifyJS2/pull/2658) ([alexlamsl](https://github.com/alexlamsl))
+- improve `unused` over duplicate variable names [\#2656](https://github.com/mishoo/UglifyJS2/pull/2656) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.2](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.2) (2017-12-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.2...harmony-v3.3.2)
+
+**Merged pull requests:**
+
+- Harmony v3.3.2 [\#2654](https://github.com/mishoo/UglifyJS2/pull/2654) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.2](https://github.com/mishoo/UglifyJS2/tree/v3.3.2) (2017-12-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.1...v3.3.2)
+
+**Merged pull requests:**
+
+- parse LF & comment correctly [\#2653](https://github.com/mishoo/UglifyJS2/pull/2653) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.1](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.1) (2017-12-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.1...harmony-v3.3.1)
+
+**Merged pull requests:**
+
+- Harmony v3.3.1 [\#2649](https://github.com/mishoo/UglifyJS2/pull/2649) ([alexlamsl](https://github.com/alexlamsl))
+- handle non-ES5 node types in `inline` [\#2648](https://github.com/mishoo/UglifyJS2/pull/2648) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.1](https://github.com/mishoo/UglifyJS2/tree/v3.3.1) (2017-12-24)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.3.0...v3.3.1)
+
+**Merged pull requests:**
+
+- add `html-minifier` to benchmarks [\#2646](https://github.com/mishoo/UglifyJS2/pull/2646) ([alexlamsl](https://github.com/alexlamsl))
+- fix infinite loop during `inline` [\#2645](https://github.com/mishoo/UglifyJS2/pull/2645) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.3.0](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.3.0) (2017-12-24)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.3.0...harmony-v3.3.0)
+
+**Merged pull requests:**
+
+- Harmony v3.3.0 [\#2643](https://github.com/mishoo/UglifyJS2/pull/2643) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.3.0](https://github.com/mishoo/UglifyJS2/tree/v3.3.0) (2017-12-24)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.2.2...v3.3.0)
+
+**Merged pull requests:**
+
+- fix comments output & improve `/\*@\_\_PURE\_\_\*/` [\#2639](https://github.com/mishoo/UglifyJS2/pull/2639) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner cases with `collapse\_vars`, `inline` & `reduce\_vars` [\#2637](https://github.com/mishoo/UglifyJS2/pull/2637) ([alexlamsl](https://github.com/alexlamsl))
+- fix escape analysis on `AST\_PropAccess` [\#2636](https://github.com/mishoo/UglifyJS2/pull/2636) ([alexlamsl](https://github.com/alexlamsl))
+- make comments output more robust [\#2633](https://github.com/mishoo/UglifyJS2/pull/2633) ([alexlamsl](https://github.com/alexlamsl))
+- `arrows` fix for object literal methods containing `arguments` [\#2632](https://github.com/mishoo/UglifyJS2/pull/2632) ([kzc](https://github.com/kzc))
+- remove AST hack from `inline` [\#2627](https://github.com/mishoo/UglifyJS2/pull/2627) ([alexlamsl](https://github.com/alexlamsl))
+- disable `hoist\_funs` by default [\#2626](https://github.com/mishoo/UglifyJS2/pull/2626) ([alexlamsl](https://github.com/alexlamsl))
+- avoid `inline` of function with special argument names [\#2625](https://github.com/mishoo/UglifyJS2/pull/2625) ([alexlamsl](https://github.com/alexlamsl))
+- fix `inline` after single-use `reduce\_vars` [\#2623](https://github.com/mishoo/UglifyJS2/pull/2623) ([alexlamsl](https://github.com/alexlamsl))
+- Simplify transform [\#2621](https://github.com/mishoo/UglifyJS2/pull/2621) ([OndrejSpanel](https://github.com/OndrejSpanel))
+- extend `test/ufuzz.js` to `inline` & `reduce\_funcs` [\#2620](https://github.com/mishoo/UglifyJS2/pull/2620) ([alexlamsl](https://github.com/alexlamsl))
+- add test for \#2613 [\#2618](https://github.com/mishoo/UglifyJS2/pull/2618) ([alexlamsl](https://github.com/alexlamsl))
+- handle global constant collision with local variable after `inline` [\#2617](https://github.com/mishoo/UglifyJS2/pull/2617) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix slowness in `unused` for blocks [\#2614](https://github.com/mishoo/UglifyJS2/pull/2614) ([kzc](https://github.com/kzc))
+- compress `apply\(\)` & `call\(\)` of `function` [\#2613](https://github.com/mishoo/UglifyJS2/pull/2613) ([alexlamsl](https://github.com/alexlamsl))
+- drop property assignment to constants [\#2612](https://github.com/mishoo/UglifyJS2/pull/2612) ([alexlamsl](https://github.com/alexlamsl))
+- improve transversal efficiency in `collapse\_vars` [\#2611](https://github.com/mishoo/UglifyJS2/pull/2611) ([alexlamsl](https://github.com/alexlamsl))
+- improve `reset\_opt\_flags\(\)` [\#2610](https://github.com/mishoo/UglifyJS2/pull/2610) ([alexlamsl](https://github.com/alexlamsl))
+- export `parse\(\)` [\#2608](https://github.com/mishoo/UglifyJS2/pull/2608) ([alexlamsl](https://github.com/alexlamsl))
+- fix `export default` of anonymous generators and async functions [\#2607](https://github.com/mishoo/UglifyJS2/pull/2607) ([kzc](https://github.com/kzc))
+- account for `catch` variable when `inline` [\#2605](https://github.com/mishoo/UglifyJS2/pull/2605) ([alexlamsl](https://github.com/alexlamsl))
+- fix nested `inline` [\#2602](https://github.com/mishoo/UglifyJS2/pull/2602) ([alexlamsl](https://github.com/alexlamsl))
+- fix escape analysis on `||` and `&&` [\#2600](https://github.com/mishoo/UglifyJS2/pull/2600) ([alexlamsl](https://github.com/alexlamsl))
+- fix `dead\_code` on nested `try` [\#2599](https://github.com/mishoo/UglifyJS2/pull/2599) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on `do...while` [\#2596](https://github.com/mishoo/UglifyJS2/pull/2596) ([alexlamsl](https://github.com/alexlamsl))
+- inline single-use `function` across loop [\#2594](https://github.com/mishoo/UglifyJS2/pull/2594) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on single `AST\_Defun` reference across loop [\#2593](https://github.com/mishoo/UglifyJS2/pull/2593) ([alexlamsl](https://github.com/alexlamsl))
+- improve `reduce\_vars` [\#2592](https://github.com/mishoo/UglifyJS2/pull/2592) ([alexlamsl](https://github.com/alexlamsl))
+- improve `collapse\_vars` [\#2591](https://github.com/mishoo/UglifyJS2/pull/2591) ([alexlamsl](https://github.com/alexlamsl))
+- handle `inline` of function arguments [\#2590](https://github.com/mishoo/UglifyJS2/pull/2590) ([alexlamsl](https://github.com/alexlamsl))
+- improve `dead\_code` tests [\#2589](https://github.com/mishoo/UglifyJS2/pull/2589) ([kzc](https://github.com/kzc))
+- fix `dead\_code` on `return`/`throw` within `try` [\#2588](https://github.com/mishoo/UglifyJS2/pull/2588) ([alexlamsl](https://github.com/alexlamsl))
+- drop local assign-only variable in `return` [\#2587](https://github.com/mishoo/UglifyJS2/pull/2587) ([alexlamsl](https://github.com/alexlamsl))
+- fold `cascade` functionality into `collapse\_vars` [\#2586](https://github.com/mishoo/UglifyJS2/pull/2586) ([alexlamsl](https://github.com/alexlamsl))
+- recover lost opportunities from \#2574 [\#2584](https://github.com/mishoo/UglifyJS2/pull/2584) ([alexlamsl](https://github.com/alexlamsl))
+- improve `collapse\_vars` on side-effect-free replacements [\#2583](https://github.com/mishoo/UglifyJS2/pull/2583) ([alexlamsl](https://github.com/alexlamsl))
+- minor clean-up for IIFE [\#2582](https://github.com/mishoo/UglifyJS2/pull/2582) ([alexlamsl](https://github.com/alexlamsl))
+- avoid `Function.prototype` pollution by `test/sandbox.js` [\#2581](https://github.com/mishoo/UglifyJS2/pull/2581) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_VarDef.may\_throw\(\)` [\#2580](https://github.com/mishoo/UglifyJS2/pull/2580) ([alexlamsl](https://github.com/alexlamsl))
+- remove unused code [\#2579](https://github.com/mishoo/UglifyJS2/pull/2579) ([alexlamsl](https://github.com/alexlamsl))
+- fix `collapse\_vars` on `switch` [\#2578](https://github.com/mishoo/UglifyJS2/pull/2578) ([alexlamsl](https://github.com/alexlamsl))
+- escape consecutive unpaired surrogates [\#2576](https://github.com/mishoo/UglifyJS2/pull/2576) ([alexlamsl](https://github.com/alexlamsl))
+- rename tests [\#2575](https://github.com/mishoo/UglifyJS2/pull/2575) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.2.2](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.2.2) (2017-12-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.2.2...harmony-v3.2.2)
+
+**Merged pull requests:**
+
+- handle exceptional flow correctly in `collapse\_vars` [\#2574](https://github.com/mishoo/UglifyJS2/pull/2574) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v3.2.2 [\#2572](https://github.com/mishoo/UglifyJS2/pull/2572) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.2.2](https://github.com/mishoo/UglifyJS2/tree/v3.2.2) (2017-12-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.2.1...v3.2.2)
+
+**Merged pull requests:**
+
+- improve `unused` on assign-only symbols [\#2568](https://github.com/mishoo/UglifyJS2/pull/2568) ([alexlamsl](https://github.com/alexlamsl))
+- fix escape analysis for `AST\_Throw` [\#2564](https://github.com/mishoo/UglifyJS2/pull/2564) ([alexlamsl](https://github.com/alexlamsl))
+- fix escape analysis for `AST\_Conditional` & `AST\_Sequence` [\#2563](https://github.com/mishoo/UglifyJS2/pull/2563) ([alexlamsl](https://github.com/alexlamsl))
+- account for side-effects in conditional call inversion [\#2562](https://github.com/mishoo/UglifyJS2/pull/2562) ([alexlamsl](https://github.com/alexlamsl))
+- eliminate noop calls more aggressively [\#2559](https://github.com/mishoo/UglifyJS2/pull/2559) ([alexlamsl](https://github.com/alexlamsl))
+- improve `if\_return` [\#2558](https://github.com/mishoo/UglifyJS2/pull/2558) ([alexlamsl](https://github.com/alexlamsl))
+- simplify computed properties for methods, getters & setters [\#2555](https://github.com/mishoo/UglifyJS2/pull/2555) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.2.1](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.2.1) (2017-12-03)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.2.1...harmony-v3.2.1)
+
+**Merged pull requests:**
+
+- Harmony v3.2.1 [\#2553](https://github.com/mishoo/UglifyJS2/pull/2553) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.2.1](https://github.com/mishoo/UglifyJS2/tree/v3.2.1) (2017-12-03)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.2.0...v3.2.1)
+
+**Merged pull requests:**
+
+- fix `dead\_code` on `for` [\#2552](https://github.com/mishoo/UglifyJS2/pull/2552) ([alexlamsl](https://github.com/alexlamsl))
+- more tests for \#2535 [\#2551](https://github.com/mishoo/UglifyJS2/pull/2551) ([alexlamsl](https://github.com/alexlamsl))
+- improve `evaluate` on `typeof` [\#2550](https://github.com/mishoo/UglifyJS2/pull/2550) ([alexlamsl](https://github.com/alexlamsl))
+- improve boolean compression [\#2548](https://github.com/mishoo/UglifyJS2/pull/2548) ([alexlamsl](https://github.com/alexlamsl))
+- improve switch case compression [\#2547](https://github.com/mishoo/UglifyJS2/pull/2547) ([alexlamsl](https://github.com/alexlamsl))
+- improve `AST\_For.init` & `AST\_Switch.expression` compression [\#2546](https://github.com/mishoo/UglifyJS2/pull/2546) ([alexlamsl](https://github.com/alexlamsl))
+- convert to number under boolean context [\#2545](https://github.com/mishoo/UglifyJS2/pull/2545) ([alexlamsl](https://github.com/alexlamsl))
+- improve compression of `if` conditions [\#2544](https://github.com/mishoo/UglifyJS2/pull/2544) ([alexlamsl](https://github.com/alexlamsl))
+- improve compression of loop conditions [\#2543](https://github.com/mishoo/UglifyJS2/pull/2543) ([alexlamsl](https://github.com/alexlamsl))
+- improve code reuse [\#2542](https://github.com/mishoo/UglifyJS2/pull/2542) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in call binding [\#2541](https://github.com/mishoo/UglifyJS2/pull/2541) ([alexlamsl](https://github.com/alexlamsl))
+- backport test from \#2526 [\#2534](https://github.com/mishoo/UglifyJS2/pull/2534) ([alexlamsl](https://github.com/alexlamsl))
+- fix `inline` on nested substitutions [\#2533](https://github.com/mishoo/UglifyJS2/pull/2533) ([alexlamsl](https://github.com/alexlamsl))
+- document top level `minify\(\)` option `safari10` [\#2532](https://github.com/mishoo/UglifyJS2/pull/2532) ([kzc](https://github.com/kzc))
+- introduce `--safari10` [\#2530](https://github.com/mishoo/UglifyJS2/pull/2530) ([alexlamsl](https://github.com/alexlamsl))
+- document the new `output` option `safari10` [\#2529](https://github.com/mishoo/UglifyJS2/pull/2529) ([kzc](https://github.com/kzc))
+- add Safari workaround for `await` [\#2528](https://github.com/mishoo/UglifyJS2/pull/2528) ([alexlamsl](https://github.com/alexlamsl))
+- extend `hoist\_props` to `AST\_Arrow` & `AST\_Class` [\#2527](https://github.com/mishoo/UglifyJS2/pull/2527) ([alexlamsl](https://github.com/alexlamsl))
+- reduce `this` in block scopes [\#2526](https://github.com/mishoo/UglifyJS2/pull/2526) ([alexlamsl](https://github.com/alexlamsl))
+- replace single-use class definitions [\#2524](https://github.com/mishoo/UglifyJS2/pull/2524) ([alexlamsl](https://github.com/alexlamsl))
+- fix nested `hoist\_props` substitution [\#2523](https://github.com/mishoo/UglifyJS2/pull/2523) ([alexlamsl](https://github.com/alexlamsl))
+- drop assignment in `AST\_VarDef.value` [\#2522](https://github.com/mishoo/UglifyJS2/pull/2522) ([alexlamsl](https://github.com/alexlamsl))
+- improve synergy between `collapse\_vars` & `unused` [\#2521](https://github.com/mishoo/UglifyJS2/pull/2521) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.2.0](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.2.0) (2017-11-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.2.0...harmony-v3.2.0)
+
+**Merged pull requests:**
+
+- Harmony v3.2.0 [\#2515](https://github.com/mishoo/UglifyJS2/pull/2515) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.2.0](https://github.com/mishoo/UglifyJS2/tree/v3.2.0) (2017-11-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.10...v3.2.0)
+
+**Merged pull requests:**
+
+- fix argument/atom collision by `properties` [\#2514](https://github.com/mishoo/UglifyJS2/pull/2514) ([alexlamsl](https://github.com/alexlamsl))
+- fix wording and formatting [\#2512](https://github.com/mishoo/UglifyJS2/pull/2512) ([alexlamsl](https://github.com/alexlamsl))
+- document top level minify option `keep\_classnames` [\#2511](https://github.com/mishoo/UglifyJS2/pull/2511) ([kzc](https://github.com/kzc))
+- separate `keep\_classnames` & `keep\_fnames` [\#2510](https://github.com/mishoo/UglifyJS2/pull/2510) ([alexlamsl](https://github.com/alexlamsl))
+- extend escape analysis on constant expression properties [\#2509](https://github.com/mishoo/UglifyJS2/pull/2509) ([alexlamsl](https://github.com/alexlamsl))
+- fix argument/atom collision by `collapse\_vars` [\#2507](https://github.com/mishoo/UglifyJS2/pull/2507) ([alexlamsl](https://github.com/alexlamsl))
+- make `AST\_Lambda.contains\_this\(\)` less magical [\#2505](https://github.com/mishoo/UglifyJS2/pull/2505) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on arrow functions with `this` [\#2504](https://github.com/mishoo/UglifyJS2/pull/2504) ([alexlamsl](https://github.com/alexlamsl))
+- eliminate invalid state caching in `collapse\_vars` [\#2502](https://github.com/mishoo/UglifyJS2/pull/2502) ([alexlamsl](https://github.com/alexlamsl))
+- fix `rename` [\#2501](https://github.com/mishoo/UglifyJS2/pull/2501) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `properties` for array literal with spread [\#2499](https://github.com/mishoo/UglifyJS2/pull/2499) ([kzc](https://github.com/kzc))
+- expand symbol space to improve compression [\#2460](https://github.com/mishoo/UglifyJS2/pull/2460) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.10](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.10) (2017-11-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.10...harmony-v3.1.10)
+
+**Merged pull requests:**
+
+- Harmony v3.1.10 [\#2494](https://github.com/mishoo/UglifyJS2/pull/2494) ([alexlamsl](https://github.com/alexlamsl))
+- fix keyword shorthand property output for `ecma` \>= 6 [\#2493](https://github.com/mishoo/UglifyJS2/pull/2493) ([kzc](https://github.com/kzc))
+- enable `hoist\_props` by default [\#2492](https://github.com/mishoo/UglifyJS2/pull/2492) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.10](https://github.com/mishoo/UglifyJS2/tree/v3.1.10) (2017-11-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.9...v3.1.10)
+
+**Merged pull requests:**
+
+- document the `webkit` output option [\#2490](https://github.com/mishoo/UglifyJS2/pull/2490) ([kzc](https://github.com/kzc))
+- \[ES6\] fix template expression parse of regex and sequence [\#2488](https://github.com/mishoo/UglifyJS2/pull/2488) ([kzc](https://github.com/kzc))
+- fix cross-scope inlining of `AST\_Function`s [\#2486](https://github.com/mishoo/UglifyJS2/pull/2486) ([alexlamsl](https://github.com/alexlamsl))
+- minor consolidations [\#2484](https://github.com/mishoo/UglifyJS2/pull/2484) ([alexlamsl](https://github.com/alexlamsl))
+- Update ISSUE\_TEMPLATE.md [\#2481](https://github.com/mishoo/UglifyJS2/pull/2481) ([kzc](https://github.com/kzc))
+- update documentation for `reduce\_funcs` [\#2478](https://github.com/mishoo/UglifyJS2/pull/2478) ([kzc](https://github.com/kzc))
+- fix replacement logic in `collapse\_vars` [\#2475](https://github.com/mishoo/UglifyJS2/pull/2475) ([alexlamsl](https://github.com/alexlamsl))
+- fix `top\_retain` on `hoist\_props` [\#2474](https://github.com/mishoo/UglifyJS2/pull/2474) ([alexlamsl](https://github.com/alexlamsl))
+- allow symbol replacement on multiple occurrences [\#2472](https://github.com/mishoo/UglifyJS2/pull/2472) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.9](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.9) (2017-11-11)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.9...harmony-v3.1.9)
+
+**Merged pull requests:**
+
+- Harmony v3.1.9 [\#2470](https://github.com/mishoo/UglifyJS2/pull/2470) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.9](https://github.com/mishoo/UglifyJS2/tree/v3.1.9) (2017-11-11)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.8...v3.1.9)
+
+**Merged pull requests:**
+
+- extend `reduce\_funcs` to cover cross-scope substitutions [\#2469](https://github.com/mishoo/UglifyJS2/pull/2469) ([alexlamsl](https://github.com/alexlamsl))
+- implement compress option `reduce\_funcs` [\#2466](https://github.com/mishoo/UglifyJS2/pull/2466) ([alexlamsl](https://github.com/alexlamsl))
+- suppress `hoist\_props` on `export` [\#2463](https://github.com/mishoo/UglifyJS2/pull/2463) ([alexlamsl](https://github.com/alexlamsl))
+- fix object literal tracing in `reduce\_vars` [\#2461](https://github.com/mishoo/UglifyJS2/pull/2461) ([alexlamsl](https://github.com/alexlamsl))
+- fix multiple nested function substitutions [\#2458](https://github.com/mishoo/UglifyJS2/pull/2458) ([alexlamsl](https://github.com/alexlamsl))
+- remove hack in `collapse\_vars` [\#2457](https://github.com/mishoo/UglifyJS2/pull/2457) ([alexlamsl](https://github.com/alexlamsl))
+- fix `const` under `collapse\_vars` without `unused` [\#2454](https://github.com/mishoo/UglifyJS2/pull/2454) ([alexlamsl](https://github.com/alexlamsl))
+- preserve function identity in `reduce\_vars` [\#2451](https://github.com/mishoo/UglifyJS2/pull/2451) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.8](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.8) (2017-11-06)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.8...harmony-v3.1.8)
+
+**Merged pull requests:**
+
+- Harmony v3.1.8 [\#2448](https://github.com/mishoo/UglifyJS2/pull/2448) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.8](https://github.com/mishoo/UglifyJS2/tree/v3.1.8) (2017-11-06)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.7...v3.1.8)
+
+**Merged pull requests:**
+
+- handle circular `function` reference gracefully [\#2446](https://github.com/mishoo/UglifyJS2/pull/2446) ([alexlamsl](https://github.com/alexlamsl))
+- account for `eval` & `with` in `reduce\_vars` [\#2441](https://github.com/mishoo/UglifyJS2/pull/2441) ([alexlamsl](https://github.com/alexlamsl))
+- consolidate & enhance `unused` [\#2439](https://github.com/mishoo/UglifyJS2/pull/2439) ([alexlamsl](https://github.com/alexlamsl))
+- inline single-use functions that are not constant expressions [\#2434](https://github.com/mishoo/UglifyJS2/pull/2434) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.7](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.7) (2017-11-05)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.7...harmony-v3.1.7)
+
+**Merged pull requests:**
+
+- Harmony v3.1.7 [\#2433](https://github.com/mishoo/UglifyJS2/pull/2433) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.7](https://github.com/mishoo/UglifyJS2/tree/v3.1.7) (2017-11-05)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.6...v3.1.7)
+
+**Merged pull requests:**
+
+- tweak \#2424 [\#2432](https://github.com/mishoo/UglifyJS2/pull/2432) ([alexlamsl](https://github.com/alexlamsl))
+- extend function inlining safety checks [\#2430](https://github.com/mishoo/UglifyJS2/pull/2430) ([alexlamsl](https://github.com/alexlamsl))
+- consolidate single-use `function` reduction [\#2427](https://github.com/mishoo/UglifyJS2/pull/2427) ([alexlamsl](https://github.com/alexlamsl))
+- maintain call argument order in `collapse\_vars` [\#2426](https://github.com/mishoo/UglifyJS2/pull/2426) ([alexlamsl](https://github.com/alexlamsl))
+- improve variations on call arguments for `ufuzz` [\#2424](https://github.com/mishoo/UglifyJS2/pull/2424) ([alexlamsl](https://github.com/alexlamsl))
+- reduce `this` within functions [\#2421](https://github.com/mishoo/UglifyJS2/pull/2421) ([alexlamsl](https://github.com/alexlamsl))
+- compress `new` `function` containing `this` [\#2417](https://github.com/mishoo/UglifyJS2/pull/2417) ([alexlamsl](https://github.com/alexlamsl))
+- hoist\_props: hoisting of some class expressions [\#2415](https://github.com/mishoo/UglifyJS2/pull/2415) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.1.6](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.6) (2017-10-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.6...harmony-v3.1.6)
+
+**Merged pull requests:**
+
+- Harmony v3.1.6 [\#2413](https://github.com/mishoo/UglifyJS2/pull/2413) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.6](https://github.com/mishoo/UglifyJS2/tree/v3.1.6) (2017-10-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.5...v3.1.6)
+
+**Merged pull requests:**
+
+- enhance `properties` [\#2412](https://github.com/mishoo/UglifyJS2/pull/2412) ([alexlamsl](https://github.com/alexlamsl))
+- consistently reduce `const` safe literals [\#2411](https://github.com/mishoo/UglifyJS2/pull/2411) ([alexlamsl](https://github.com/alexlamsl))
+- fix & improve `AST\_TemplateString` [\#2410](https://github.com/mishoo/UglifyJS2/pull/2410) ([alexlamsl](https://github.com/alexlamsl))
+- remove dead code [\#2405](https://github.com/mishoo/UglifyJS2/pull/2405) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on `AST\_Array.length` [\#2404](https://github.com/mishoo/UglifyJS2/pull/2404) ([alexlamsl](https://github.com/alexlamsl))
+- document compress option `hoist\_props` [\#2399](https://github.com/mishoo/UglifyJS2/pull/2399) ([kzc](https://github.com/kzc))
+- compress self comparisons [\#2398](https://github.com/mishoo/UglifyJS2/pull/2398) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` `reduce\_vars` on arrays & objects [\#2397](https://github.com/mishoo/UglifyJS2/pull/2397) ([alexlamsl](https://github.com/alexlamsl))
+- implement `hoist\_props` [\#2396](https://github.com/mishoo/UglifyJS2/pull/2396) ([alexlamsl](https://github.com/alexlamsl))
+- docs: Fix spelling and style [\#2395](https://github.com/mishoo/UglifyJS2/pull/2395) ([tmcw](https://github.com/tmcw))
+- enhance `unsafe` `evaluate` of arrays & objects [\#2394](https://github.com/mishoo/UglifyJS2/pull/2394) ([alexlamsl](https://github.com/alexlamsl))
+- deduplicate declarations regardless of `toplevel` [\#2393](https://github.com/mishoo/UglifyJS2/pull/2393) ([alexlamsl](https://github.com/alexlamsl))
+- fix `dead\_code` on `AST\_Destructuring` [\#2392](https://github.com/mishoo/UglifyJS2/pull/2392) ([alexlamsl](https://github.com/alexlamsl))
+- safer `properties` transform [\#2391](https://github.com/mishoo/UglifyJS2/pull/2391) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` expansion of object literals [\#2390](https://github.com/mishoo/UglifyJS2/pull/2390) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` evaluation of `AST\_Sub` [\#2389](https://github.com/mishoo/UglifyJS2/pull/2389) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` evaluation of objects [\#2388](https://github.com/mishoo/UglifyJS2/pull/2388) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` escape analysis in `reduce\_vars` [\#2387](https://github.com/mishoo/UglifyJS2/pull/2387) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.5](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.5) (2017-10-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.5...harmony-v3.1.5)
+
+**Merged pull requests:**
+
+- Harmony v3.1.5 [\#2386](https://github.com/mishoo/UglifyJS2/pull/2386) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.5](https://github.com/mishoo/UglifyJS2/tree/v3.1.5) (2017-10-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.4...v3.1.5)
+
+**Merged pull requests:**
+
+- Allow 'yield' as method name [\#2382](https://github.com/mishoo/UglifyJS2/pull/2382) ([t-sauer](https://github.com/t-sauer))
+- `unsafe` fix-ups for \#2351 [\#2379](https://github.com/mishoo/UglifyJS2/pull/2379) ([alexlamsl](https://github.com/alexlamsl))
+- backport \#2374 [\#2376](https://github.com/mishoo/UglifyJS2/pull/2376) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_PropAccess` in `collapse\_vars` \(take 3\) [\#2375](https://github.com/mishoo/UglifyJS2/pull/2375) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] compress option formatting in docs [\#2374](https://github.com/mishoo/UglifyJS2/pull/2374) ([kzc](https://github.com/kzc))
+- clean up lazy operator detection [\#2373](https://github.com/mishoo/UglifyJS2/pull/2373) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_PropAccess` in `collapse\_vars` \(take 2\) [\#2372](https://github.com/mishoo/UglifyJS2/pull/2372) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_PropAccess` in `collapse\_vars` [\#2370](https://github.com/mishoo/UglifyJS2/pull/2370) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `collapse\_vars` around lazy operations [\#2369](https://github.com/mishoo/UglifyJS2/pull/2369) ([alexlamsl](https://github.com/alexlamsl))
+- deduplicate `AST\_Super` & `AST\_This` logic [\#2366](https://github.com/mishoo/UglifyJS2/pull/2366) ([alexlamsl](https://github.com/alexlamsl))
+- account for side-effects from `AST\_This` in `collapse\_vars` [\#2365](https://github.com/mishoo/UglifyJS2/pull/2365) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.4](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.4) (2017-10-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.4...harmony-v3.1.4)
+
+**Merged pull requests:**
+
+- Harmony v3.1.4 [\#2363](https://github.com/mishoo/UglifyJS2/pull/2363) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] implement compress option `computed\_props` [\#2361](https://github.com/mishoo/UglifyJS2/pull/2361) ([kzc](https://github.com/kzc))
+
+## [v3.1.4](https://github.com/mishoo/UglifyJS2/tree/v3.1.4) (2017-10-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.3...v3.1.4)
+
+**Merged pull requests:**
+
+- update dependency [\#2362](https://github.com/mishoo/UglifyJS2/pull/2362) ([alexlamsl](https://github.com/alexlamsl))
+- fix-ups for \#2356 [\#2360](https://github.com/mishoo/UglifyJS2/pull/2360) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix mangle of destructuring parameters with computed properties [\#2359](https://github.com/mishoo/UglifyJS2/pull/2359) ([kzc](https://github.com/kzc))
+- more tests for \#2351 [\#2357](https://github.com/mishoo/UglifyJS2/pull/2357) ([alexlamsl](https://github.com/alexlamsl))
+- update README to include defaults [\#2356](https://github.com/mishoo/UglifyJS2/pull/2356) ([rogpeppe](https://github.com/rogpeppe))
+- Update README.md - sourceMappingURL directive note [\#2355](https://github.com/mishoo/UglifyJS2/pull/2355) ([tdmalone](https://github.com/tdmalone))
+- perform `reduce\_vars` on safe literals [\#2351](https://github.com/mishoo/UglifyJS2/pull/2351) ([alexlamsl](https://github.com/alexlamsl))
+- collapse `a.b` whenever safe [\#2350](https://github.com/mishoo/UglifyJS2/pull/2350) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `unsafe` join\(\) on array literal with spread [\#2347](https://github.com/mishoo/UglifyJS2/pull/2347) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.1.3](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.3) (2017-10-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.3...harmony-v3.1.3)
+
+**Merged pull requests:**
+
+- Harmony v3.1.3 [\#2341](https://github.com/mishoo/UglifyJS2/pull/2341) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.3](https://github.com/mishoo/UglifyJS2/tree/v3.1.3) (2017-10-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.2...v3.1.3)
+
+**Merged pull requests:**
+
+- enhance `reduce\_vars` for `AST\_Accessor` [\#2339](https://github.com/mishoo/UglifyJS2/pull/2339) ([alexlamsl](https://github.com/alexlamsl))
+- trap invalid use of reserved words [\#2338](https://github.com/mishoo/UglifyJS2/pull/2338) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES9\] support dynamic `import\(\)`, trap invalid use of `export` [\#2335](https://github.com/mishoo/UglifyJS2/pull/2335) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.1.2](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.2) (2017-09-24)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.2...harmony-v3.1.2)
+
+**Merged pull requests:**
+
+- Harmony v3.1.2 [\#2330](https://github.com/mishoo/UglifyJS2/pull/2330) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.2](https://github.com/mishoo/UglifyJS2/tree/v3.1.2) (2017-09-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.1...v3.1.2)
+
+**Merged pull requests:**
+
+- fix "use asm" numeric output in function expressions [\#2328](https://github.com/mishoo/UglifyJS2/pull/2328) ([kzc](https://github.com/kzc))
+- \[ES6\] allow RegExp for `unsafe\_methods` compress option [\#2327](https://github.com/mishoo/UglifyJS2/pull/2327) ([kzc](https://github.com/kzc))
+- suppress `collapse\_vars` of `this` into "use strict" [\#2326](https://github.com/mishoo/UglifyJS2/pull/2326) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] add new compress option `unsafe\_methods` for ecma \>= 6 [\#2325](https://github.com/mishoo/UglifyJS2/pull/2325) ([kzc](https://github.com/kzc))
+- mangle: do not mangle reserved class [\#2317](https://github.com/mishoo/UglifyJS2/pull/2317) ([jlguenego](https://github.com/jlguenego))
+
+## [harmony-v3.1.1](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.1) (2017-09-17)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.1...harmony-v3.1.1)
+
+**Merged pull requests:**
+
+- Harmony v3.1.1 [\#2315](https://github.com/mishoo/UglifyJS2/pull/2315) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.1](https://github.com/mishoo/UglifyJS2/tree/v3.1.1) (2017-09-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.1.0...v3.1.1)
+
+**Merged pull requests:**
+
+- handle LHS side-effects on `cascade` & `collapse\_vars` [\#2314](https://github.com/mishoo/UglifyJS2/pull/2314) ([alexlamsl](https://github.com/alexlamsl))
+- improve source mapping [\#2312](https://github.com/mishoo/UglifyJS2/pull/2312) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.1.0](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.1.0) (2017-09-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.1.0...harmony-v3.1.0)
+
+**Merged pull requests:**
+
+- Harmony v3.1.0 [\#2307](https://github.com/mishoo/UglifyJS2/pull/2307) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.1.0](https://github.com/mishoo/UglifyJS2/tree/v3.1.0) (2017-09-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.28...v3.1.0)
+
+**Merged pull requests:**
+
+- Testing all leading comments against being PURE comments [\#2305](https://github.com/mishoo/UglifyJS2/pull/2305) ([Andarist](https://github.com/Andarist))
+- extend `unsafe` on pure global functions [\#2303](https://github.com/mishoo/UglifyJS2/pull/2303) ([alexlamsl](https://github.com/alexlamsl))
+- add `Date` and other known globals to `unsafe` compress option [\#2302](https://github.com/mishoo/UglifyJS2/pull/2302) ([kzc](https://github.com/kzc))
+- fix `collapse\_vars` on default function argument [\#2299](https://github.com/mishoo/UglifyJS2/pull/2299) ([alexlamsl](https://github.com/alexlamsl))
+- correctly count declarations after `hoist\_vars` [\#2297](https://github.com/mishoo/UglifyJS2/pull/2297) ([alexlamsl](https://github.com/alexlamsl))
+- Fix CLI example for mangle reserved list of names [\#2294](https://github.com/mishoo/UglifyJS2/pull/2294) ([Dazix](https://github.com/Dazix))
+- \[ES6\] avoid generating ternary with spread [\#2293](https://github.com/mishoo/UglifyJS2/pull/2293) ([kzc](https://github.com/kzc))
+- Fix CLI source-maps examples [\#2291](https://github.com/mishoo/UglifyJS2/pull/2291) ([Dazix](https://github.com/Dazix))
+- fix `unused` patching of `AST\_For.init` blocks [\#2289](https://github.com/mishoo/UglifyJS2/pull/2289) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.28](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.28) (2017-08-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.28...harmony-v3.0.28)
+
+**Merged pull requests:**
+
+- Harmony v3.0.28 [\#2281](https://github.com/mishoo/UglifyJS2/pull/2281) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.28](https://github.com/mishoo/UglifyJS2/tree/v3.0.28) (2017-08-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.27...v3.0.28)
+
+**Merged pull requests:**
+
+- Introduce new compress option `unsafe\_arrows` [\#2278](https://github.com/mishoo/UglifyJS2/pull/2278) ([kzc](https://github.com/kzc))
+- \[ES6\] prohibit let/const redeclaration [\#2277](https://github.com/mishoo/UglifyJS2/pull/2277) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `pure\_getters` on spread of objects [\#2275](https://github.com/mishoo/UglifyJS2/pull/2275) ([alexlamsl](https://github.com/alexlamsl))
+- Don't escape null characters as \0 when followed by any digit [\#2273](https://github.com/mishoo/UglifyJS2/pull/2273) ([erikdesjardins](https://github.com/erikdesjardins))
+- \[ES6\] fix output of spread of a sequence [\#2268](https://github.com/mishoo/UglifyJS2/pull/2268) ([kzc](https://github.com/kzc))
+- \[ES9\] implement object rest/spread [\#2265](https://github.com/mishoo/UglifyJS2/pull/2265) ([kzc](https://github.com/kzc))
+- fix `ie8` mangling of top-level `AST\_SymbolCatch` [\#2263](https://github.com/mishoo/UglifyJS2/pull/2263) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.27](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.27) (2017-07-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.27...harmony-v3.0.27)
+
+**Merged pull requests:**
+
+- Harmony v3.0.27 [\#2262](https://github.com/mishoo/UglifyJS2/pull/2262) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.27](https://github.com/mishoo/UglifyJS2/tree/v3.0.27) (2017-07-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.26...v3.0.27)
+
+**Merged pull requests:**
+
+- improve `mangle.properties` [\#2261](https://github.com/mishoo/UglifyJS2/pull/2261) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] have `keep\_quoted` respect quoted method names [\#2258](https://github.com/mishoo/UglifyJS2/pull/2258) ([kzc](https://github.com/kzc))
+- issue template: describe acceptable JS input [\#2255](https://github.com/mishoo/UglifyJS2/pull/2255) ([kzc](https://github.com/kzc))
+- \[ES6\] extend `collapse\_vars` to `let` and `const` [\#2252](https://github.com/mishoo/UglifyJS2/pull/2252) ([alexlamsl](https://github.com/alexlamsl))
+- enhance test for \#2242 [\#2248](https://github.com/mishoo/UglifyJS2/pull/2248) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.26](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.26) (2017-07-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.26...harmony-v3.0.26)
+
+**Merged pull requests:**
+
+- Harmony v3.0.26 [\#2247](https://github.com/mishoo/UglifyJS2/pull/2247) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.26](https://github.com/mishoo/UglifyJS2/tree/v3.0.26) (2017-07-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.25...v3.0.26)
+
+**Merged pull requests:**
+
+- unescape surrogate pairs only [\#2246](https://github.com/mishoo/UglifyJS2/pull/2246) ([alexlamsl](https://github.com/alexlamsl))
+- update dependencies [\#2241](https://github.com/mishoo/UglifyJS2/pull/2241) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.25](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.25) (2017-07-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.25...harmony-v3.0.25)
+
+**Merged pull requests:**
+
+- Harmony v3.0.25 [\#2240](https://github.com/mishoo/UglifyJS2/pull/2240) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.25](https://github.com/mishoo/UglifyJS2/tree/v3.0.25) (2017-07-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.24...v3.0.25)
+
+**Merged pull requests:**
+
+- reject malformed CLI parameters [\#2239](https://github.com/mishoo/UglifyJS2/pull/2239) ([alexlamsl](https://github.com/alexlamsl))
+- ensure `ie8` works with mangled properties [\#2238](https://github.com/mishoo/UglifyJS2/pull/2238) ([alexlamsl](https://github.com/alexlamsl))
+- drop `unused` builtin globals under `unsafe` [\#2236](https://github.com/mishoo/UglifyJS2/pull/2236) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unsafe` `evaluate` of `Object` static methods [\#2232](https://github.com/mishoo/UglifyJS2/pull/2232) ([alexlamsl](https://github.com/alexlamsl))
+- drop `unused` compound assignments [\#2230](https://github.com/mishoo/UglifyJS2/pull/2230) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `passes` [\#2229](https://github.com/mishoo/UglifyJS2/pull/2229) ([alexlamsl](https://github.com/alexlamsl))
+- fix gzip stream in `test/benchmark.js` [\#2228](https://github.com/mishoo/UglifyJS2/pull/2228) ([alexlamsl](https://github.com/alexlamsl))
+- enhance source mapping on IIFEs [\#2224](https://github.com/mishoo/UglifyJS2/pull/2224) ([alexlamsl](https://github.com/alexlamsl))
+- uglify-es: update repository and project tagline [\#2221](https://github.com/mishoo/UglifyJS2/pull/2221) ([kzc](https://github.com/kzc))
+- benchmark gzipped output [\#2220](https://github.com/mishoo/UglifyJS2/pull/2220) ([alexlamsl](https://github.com/alexlamsl))
+- docs: update benchmarks using node 8, add babili [\#2218](https://github.com/mishoo/UglifyJS2/pull/2218) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.24](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.24) (2017-07-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.24...harmony-v3.0.24)
+
+**Merged pull requests:**
+
+- Harmony v3.0.24 [\#2216](https://github.com/mishoo/UglifyJS2/pull/2216) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.24](https://github.com/mishoo/UglifyJS2/tree/v3.0.24) (2017-07-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.23...v3.0.24)
+
+**Merged pull requests:**
+
+- handle duplicate argument names in `collapse\_vars` [\#2215](https://github.com/mishoo/UglifyJS2/pull/2215) ([alexlamsl](https://github.com/alexlamsl))
+- uglify-es: have repository point to harmony branch [\#2212](https://github.com/mishoo/UglifyJS2/pull/2212) ([kzc](https://github.com/kzc))
+- inlining of static methods & constants [\#2211](https://github.com/mishoo/UglifyJS2/pull/2211) ([alexlamsl](https://github.com/alexlamsl))
+- inline property access of object literal [\#2209](https://github.com/mishoo/UglifyJS2/pull/2209) ([alexlamsl](https://github.com/alexlamsl))
+- suppress `collapse\_vars` of `this` as call argument [\#2204](https://github.com/mishoo/UglifyJS2/pull/2204) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] improve `AST\_ConciseMethod` compression [\#2202](https://github.com/mishoo/UglifyJS2/pull/2202) ([alexlamsl](https://github.com/alexlamsl))
+- improve `compress` granularity through `typeofs` [\#2201](https://github.com/mishoo/UglifyJS2/pull/2201) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Convert `p: function\(\){}` to `p\(\){}` in object literals [\#2199](https://github.com/mishoo/UglifyJS2/pull/2199) ([kzc](https://github.com/kzc))
+- minor clean-ups to `evaluate` [\#2197](https://github.com/mishoo/UglifyJS2/pull/2197) ([alexlamsl](https://github.com/alexlamsl))
+- improve parenthesis emission [\#2196](https://github.com/mishoo/UglifyJS2/pull/2196) ([alexlamsl](https://github.com/alexlamsl))
+- clean up `TreeWalker.pop\(\)` [\#2195](https://github.com/mishoo/UglifyJS2/pull/2195) ([alexlamsl](https://github.com/alexlamsl))
+- document fast mangle-only minify mode [\#2194](https://github.com/mishoo/UglifyJS2/pull/2194) ([kzc](https://github.com/kzc))
+- refactor `throw` usage within `compress` [\#2193](https://github.com/mishoo/UglifyJS2/pull/2193) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.23](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.23) (2017-07-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.23...harmony-v3.0.23)
+
+**Merged pull requests:**
+
+- Harmony v3.0.23 [\#2192](https://github.com/mishoo/UglifyJS2/pull/2192) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.23](https://github.com/mishoo/UglifyJS2/tree/v3.0.23) (2017-07-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.22...v3.0.23)
+
+**Merged pull requests:**
+
+- drop argument value after `collapse\_vars` [\#2190](https://github.com/mishoo/UglifyJS2/pull/2190) ([alexlamsl](https://github.com/alexlamsl))
+- improve `inline` efficiency [\#2188](https://github.com/mishoo/UglifyJS2/pull/2188) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.22](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.22) (2017-06-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.22...harmony-v3.0.22)
+
+**Merged pull requests:**
+
+- Harmony v3.0.22 [\#2186](https://github.com/mishoo/UglifyJS2/pull/2186) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.22](https://github.com/mishoo/UglifyJS2/tree/v3.0.22) (2017-06-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.21...v3.0.22)
+
+**Merged pull requests:**
+
+- \[ES6\] remove extraneous `!` before `AST\_Arrow` [\#2185](https://github.com/mishoo/UglifyJS2/pull/2185) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES8\] async arrow function IIFE fix [\#2184](https://github.com/mishoo/UglifyJS2/pull/2184) ([kzc](https://github.com/kzc))
+- \[ES8\] fix `await` parens for property expressions and calls [\#2181](https://github.com/mishoo/UglifyJS2/pull/2181) ([kzc](https://github.com/kzc))
+- improve usability of name cache under `minify\(\)` [\#2176](https://github.com/mishoo/UglifyJS2/pull/2176) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.21](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.21) (2017-06-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.21...harmony-v3.0.21)
+
+**Merged pull requests:**
+
+- Harmony v3.0.21 [\#2177](https://github.com/mishoo/UglifyJS2/pull/2177) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.21](https://github.com/mishoo/UglifyJS2/tree/v3.0.21) (2017-06-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.20...v3.0.21)
+
+**Merged pull requests:**
+
+- \[ES6\] document mangle option `keep\_classnames` [\#2175](https://github.com/mishoo/UglifyJS2/pull/2175) ([kzc](https://github.com/kzc))
+- \[ES6\] fix line terminators in template literals [\#2173](https://github.com/mishoo/UglifyJS2/pull/2173) ([alexlamsl](https://github.com/alexlamsl))
+- improve `unsafe\_Func` [\#2171](https://github.com/mishoo/UglifyJS2/pull/2171) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] compress `AST\_Arrow` properly [\#2170](https://github.com/mishoo/UglifyJS2/pull/2170) ([alexlamsl](https://github.com/alexlamsl))
+- parse `@global\_defs` as expressions [\#2169](https://github.com/mishoo/UglifyJS2/pull/2169) ([alexlamsl](https://github.com/alexlamsl))
+- update `uglify-es` keywords in package.json [\#2168](https://github.com/mishoo/UglifyJS2/pull/2168) ([kzc](https://github.com/kzc))
+- \[ES6\] fix `side\_effects` on `AST\_Expansion` [\#2165](https://github.com/mishoo/UglifyJS2/pull/2165) ([alexlamsl](https://github.com/alexlamsl))
+- update doc notes for `uglify-es` [\#2164](https://github.com/mishoo/UglifyJS2/pull/2164) ([kzc](https://github.com/kzc))
+- \[ES6\] more documentation for the `ecma` option [\#2162](https://github.com/mishoo/UglifyJS2/pull/2162) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.20](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.20) (2017-06-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.20...harmony-v3.0.20)
+
+**Merged pull requests:**
+
+- Harmony v3.0.20 [\#2161](https://github.com/mishoo/UglifyJS2/pull/2161) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.20](https://github.com/mishoo/UglifyJS2/tree/v3.0.20) (2017-06-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.19...v3.0.20)
+
+**Merged pull requests:**
+
+- more tests for \#2158 [\#2160](https://github.com/mishoo/UglifyJS2/pull/2160) ([alexlamsl](https://github.com/alexlamsl))
+- fix `cascade` & `collapse\_vars` on property access of constants [\#2158](https://github.com/mishoo/UglifyJS2/pull/2158) ([alexlamsl](https://github.com/alexlamsl))
+- toplevel shorthand for `ecma` [\#2157](https://github.com/mishoo/UglifyJS2/pull/2157) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES8\] support trailing commas in function parameter lists and calls [\#2156](https://github.com/mishoo/UglifyJS2/pull/2156) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] add new `arrows` compress option [\#2154](https://github.com/mishoo/UglifyJS2/pull/2154) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] support async arrow functions [\#2153](https://github.com/mishoo/UglifyJS2/pull/2153) ([alexlamsl](https://github.com/alexlamsl))
+- refactor `compute\_char\_frequency\(\)` [\#2152](https://github.com/mishoo/UglifyJS2/pull/2152) ([alexlamsl](https://github.com/alexlamsl))
+- synchronise `mangle.properties` for `minify\(\)` & `test/compress` [\#2151](https://github.com/mishoo/UglifyJS2/pull/2151) ([alexlamsl](https://github.com/alexlamsl))
+- refactor `Compressor.toplevel` [\#2149](https://github.com/mishoo/UglifyJS2/pull/2149) ([alexlamsl](https://github.com/alexlamsl))
+- minimise `reduce\_vars` cloning overhead [\#2148](https://github.com/mishoo/UglifyJS2/pull/2148) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unused` on `AST\_Destructuring` [\#2146](https://github.com/mishoo/UglifyJS2/pull/2146) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on `this` [\#2145](https://github.com/mishoo/UglifyJS2/pull/2145) ([alexlamsl](https://github.com/alexlamsl))
+- fix for-in loop parsing [\#2144](https://github.com/mishoo/UglifyJS2/pull/2144) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `export` of keyword and redirection [\#2143](https://github.com/mishoo/UglifyJS2/pull/2143) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.19](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.19) (2017-06-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.19...harmony-v3.0.19)
+
+**Merged pull requests:**
+
+- Harmony v3.0.19 [\#2139](https://github.com/mishoo/UglifyJS2/pull/2139) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.19](https://github.com/mishoo/UglifyJS2/tree/v3.0.19) (2017-06-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.18...v3.0.19)
+
+**Merged pull requests:**
+
+- \[ES6\] fix `inline` & `unused` on `AST\_Expansion` [\#2138](https://github.com/mishoo/UglifyJS2/pull/2138) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `toplevel` on `export` [\#2137](https://github.com/mishoo/UglifyJS2/pull/2137) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] correctly parse `export` of `function` & `class` [\#2135](https://github.com/mishoo/UglifyJS2/pull/2135) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `mangle` on `export` [\#2133](https://github.com/mishoo/UglifyJS2/pull/2133) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `drop\_unused\(\)` accounting of symbols within `export function` [\#2132](https://github.com/mishoo/UglifyJS2/pull/2132) ([alexlamsl](https://github.com/alexlamsl))
+- reject non-toplevel import/export [\#2128](https://github.com/mishoo/UglifyJS2/pull/2128) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] support `export` statements properly [\#2126](https://github.com/mishoo/UglifyJS2/pull/2126) ([alexlamsl](https://github.com/alexlamsl))
+- ensure mangling works if catch reuses a scope variable [\#2123](https://github.com/mishoo/UglifyJS2/pull/2123) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] retain names in export default class and function [\#2122](https://github.com/mishoo/UglifyJS2/pull/2122) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.18](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.18) (2017-06-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.18...harmony-v3.0.18)
+
+**Merged pull requests:**
+
+- Harmony v3.0.18 [\#2119](https://github.com/mishoo/UglifyJS2/pull/2119) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.18](https://github.com/mishoo/UglifyJS2/tree/v3.0.18) (2017-06-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.17...v3.0.18)
+
+**Merged pull requests:**
+
+- make defensive copies when `inline` [\#2116](https://github.com/mishoo/UglifyJS2/pull/2116) ([alexlamsl](https://github.com/alexlamsl))
+- fix loss of context in `collapse\_vars` & `cascade` [\#2112](https://github.com/mishoo/UglifyJS2/pull/2112) ([alexlamsl](https://github.com/alexlamsl))
+- in-place `tighten\_body\(\)` [\#2111](https://github.com/mishoo/UglifyJS2/pull/2111) ([alexlamsl](https://github.com/alexlamsl))
+- correctly determine scope of `AST\_This` [\#2109](https://github.com/mishoo/UglifyJS2/pull/2109) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\]\[ES8\] support shorthand property named "async" [\#2108](https://github.com/mishoo/UglifyJS2/pull/2108) ([kzc](https://github.com/kzc))
+- enforce `inline` scope restriction [\#2106](https://github.com/mishoo/UglifyJS2/pull/2106) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.17](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.17) (2017-06-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.17...harmony-v3.0.17)
+
+**Merged pull requests:**
+
+- Harmony v3.0.17 [\#2104](https://github.com/mishoo/UglifyJS2/pull/2104) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.17](https://github.com/mishoo/UglifyJS2/tree/v3.0.17) (2017-06-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.29...v3.0.17)
+
+**Merged pull requests:**
+
+- suppress `inline` of `this` [\#2103](https://github.com/mishoo/UglifyJS2/pull/2103) ([alexlamsl](https://github.com/alexlamsl))
+- avoid intermittent test time-out failures [\#2100](https://github.com/mishoo/UglifyJS2/pull/2100) ([alexlamsl](https://github.com/alexlamsl))
+- compute `uses\_arguments` correctly in `figure\_out\_scope\(\)` [\#2099](https://github.com/mishoo/UglifyJS2/pull/2099) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] first cut of async/await [\#2098](https://github.com/mishoo/UglifyJS2/pull/2098) ([kzc](https://github.com/kzc))
+
+## [v2.8.29](https://github.com/mishoo/UglifyJS2/tree/v2.8.29) (2017-06-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.16...v2.8.29)
+
+**Merged pull requests:**
+
+- fix parsing of `expect\_stdout` [\#2096](https://github.com/mishoo/UglifyJS2/pull/2096) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v3.0.16 [\#2094](https://github.com/mishoo/UglifyJS2/pull/2094) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.16](https://github.com/mishoo/UglifyJS2/tree/v3.0.16) (2017-06-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.28...v3.0.16)
+
+**Merged pull requests:**
+
+- add comment about quote\_style and gzip [\#2092](https://github.com/mishoo/UglifyJS2/pull/2092) ([kzc](https://github.com/kzc))
+- fix `reduce\_vars` on `AST\_Arrow` [\#2091](https://github.com/mishoo/UglifyJS2/pull/2091) ([alexlamsl](https://github.com/alexlamsl))
+- cache web assets between CI runs [\#2089](https://github.com/mishoo/UglifyJS2/pull/2089) ([alexlamsl](https://github.com/alexlamsl))
+- Fix use of commander's parser function's options argument \(fixes \#2082\) [\#2088](https://github.com/mishoo/UglifyJS2/pull/2088) ([zaygraveyard](https://github.com/zaygraveyard))
+- allow `expect\_stdout` to specify `Error` [\#2087](https://github.com/mishoo/UglifyJS2/pull/2087) ([alexlamsl](https://github.com/alexlamsl))
+- add Node.js 8 to Travis CI [\#2086](https://github.com/mishoo/UglifyJS2/pull/2086) ([alexlamsl](https://github.com/alexlamsl))
+- fix variable accounting in `inline` [\#2085](https://github.com/mishoo/UglifyJS2/pull/2085) ([alexlamsl](https://github.com/alexlamsl))
+- suppress false positives for-in loops [\#2080](https://github.com/mishoo/UglifyJS2/pull/2080) ([alexlamsl](https://github.com/alexlamsl))
+- fix portability of `sandbox.run\_code\(\)` on Node.js 0.1x [\#2078](https://github.com/mishoo/UglifyJS2/pull/2078) ([alexlamsl](https://github.com/alexlamsl))
+- fix non-string parameters [\#2076](https://github.com/mishoo/UglifyJS2/pull/2076) ([alexlamsl](https://github.com/alexlamsl))
+- report `test/ufuzz.js` failures in `process.stderr` [\#2074](https://github.com/mishoo/UglifyJS2/pull/2074) ([alexlamsl](https://github.com/alexlamsl))
+- marshal `mangle\[.properties\].reserved` from non-Array values [\#2072](https://github.com/mishoo/UglifyJS2/pull/2072) ([alexlamsl](https://github.com/alexlamsl))
+- fix iteration over object with inherited properties [\#2068](https://github.com/mishoo/UglifyJS2/pull/2068) ([alexlamsl](https://github.com/alexlamsl))
+- fix `cascade` on multi-branch evaluations [\#2067](https://github.com/mishoo/UglifyJS2/pull/2067) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unused` crash with top-level `AST\_Var` [\#2066](https://github.com/mishoo/UglifyJS2/pull/2066) ([alexlamsl](https://github.com/alexlamsl))
+- fix CLI output corruption [\#2061](https://github.com/mishoo/UglifyJS2/pull/2061) ([alexlamsl](https://github.com/alexlamsl))
+- fix `inline` handling of `AST\_Call.args` [\#2059](https://github.com/mishoo/UglifyJS2/pull/2059) ([alexlamsl](https://github.com/alexlamsl))
+- implement `test/jetstream.js --debug` [\#2058](https://github.com/mishoo/UglifyJS2/pull/2058) ([alexlamsl](https://github.com/alexlamsl))
+- workaround webkit parsing error [\#2056](https://github.com/mishoo/UglifyJS2/pull/2056) ([alexlamsl](https://github.com/alexlamsl))
+- implement function inlining [\#2053](https://github.com/mishoo/UglifyJS2/pull/2053) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_Function` scope invariance [\#2052](https://github.com/mishoo/UglifyJS2/pull/2052) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix class expression statements [\#2051](https://github.com/mishoo/UglifyJS2/pull/2051) ([kzc](https://github.com/kzc))
+- \[ES6\] drop unused arrow functions [\#2050](https://github.com/mishoo/UglifyJS2/pull/2050) ([kzc](https://github.com/kzc))
+
+## [v2.8.28](https://github.com/mishoo/UglifyJS2/tree/v2.8.28) (2017-06-03)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.15...v2.8.28)
+
+**Merged pull requests:**
+
+- add tests for `AST\_SymbolAccessor` [\#2049](https://github.com/mishoo/UglifyJS2/pull/2049) ([alexlamsl](https://github.com/alexlamsl))
+- backports for 2.8.28 [\#2048](https://github.com/mishoo/UglifyJS2/pull/2048) ([alexlamsl](https://github.com/alexlamsl))
+- clean up `lib/parse.js` [\#2047](https://github.com/mishoo/UglifyJS2/pull/2047) ([alexlamsl](https://github.com/alexlamsl))
+- fix `beautify` whitespace output within `AST\_Destructuring` [\#2046](https://github.com/mishoo/UglifyJS2/pull/2046) ([alexlamsl](https://github.com/alexlamsl))
+- better document behavior of unsafe\_Func [\#2043](https://github.com/mishoo/UglifyJS2/pull/2043) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.15](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.15) (2017-06-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.15...harmony-v3.0.15)
+
+**Merged pull requests:**
+
+- Harmony v3.0.15 [\#2042](https://github.com/mishoo/UglifyJS2/pull/2042) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.15](https://github.com/mishoo/UglifyJS2/tree/v3.0.15) (2017-06-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.14...v3.0.15)
+
+**Merged pull requests:**
+
+- fix non-identifier getter/setter name [\#2041](https://github.com/mishoo/UglifyJS2/pull/2041) ([alexlamsl](https://github.com/alexlamsl))
+- whitelist `unsafe` `evaluate` candidates [\#2039](https://github.com/mishoo/UglifyJS2/pull/2039) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `unsafe` `evaluate` [\#2037](https://github.com/mishoo/UglifyJS2/pull/2037) ([alexlamsl](https://github.com/alexlamsl))
+- reformat mangle options section of README [\#2036](https://github.com/mishoo/UglifyJS2/pull/2036) ([kzc](https://github.com/kzc))
+- document safari10 mangle option [\#2035](https://github.com/mishoo/UglifyJS2/pull/2035) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.14](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.14) (2017-05-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.14...harmony-v3.0.14)
+
+**Merged pull requests:**
+
+- Harmony v3.0.14 [\#2034](https://github.com/mishoo/UglifyJS2/pull/2034) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.14](https://github.com/mishoo/UglifyJS2/tree/v3.0.14) (2017-05-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.13...v3.0.14)
+
+**Merged pull requests:**
+
+- introduce `unsafe\_Func` [\#2033](https://github.com/mishoo/UglifyJS2/pull/2033) ([alexlamsl](https://github.com/alexlamsl))
+- widen CLI parse error code fragment displayed [\#2032](https://github.com/mishoo/UglifyJS2/pull/2032) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `side\_effects` on `AST\_Class` [\#2031](https://github.com/mishoo/UglifyJS2/pull/2031) ([alexlamsl](https://github.com/alexlamsl))
+- mangle destructuring function parameters [\#2029](https://github.com/mishoo/UglifyJS2/pull/2029) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix block elimination [\#2023](https://github.com/mishoo/UglifyJS2/pull/2023) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix compress of IIFE with destructuring args [\#2022](https://github.com/mishoo/UglifyJS2/pull/2022) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.13](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.13) (2017-05-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.13...harmony-v3.0.13)
+
+**Merged pull requests:**
+
+- fix `if\_return` on block-scoped variables [\#2021](https://github.com/mishoo/UglifyJS2/pull/2021) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v3.0.13 [\#2020](https://github.com/mishoo/UglifyJS2/pull/2020) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.13](https://github.com/mishoo/UglifyJS2/tree/v3.0.13) (2017-05-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.12...v3.0.13)
+
+**Merged pull requests:**
+
+- better fix for \#512 & \#2010 [\#2019](https://github.com/mishoo/UglifyJS2/pull/2019) ([alexlamsl](https://github.com/alexlamsl))
+- display default values in `--help options` [\#2018](https://github.com/mishoo/UglifyJS2/pull/2018) ([alexlamsl](https://github.com/alexlamsl))
+- implement `--help options` [\#2017](https://github.com/mishoo/UglifyJS2/pull/2017) ([alexlamsl](https://github.com/alexlamsl))
+- improve CLI usability [\#2016](https://github.com/mishoo/UglifyJS2/pull/2016) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.12](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.12) (2017-05-27)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.12...harmony-v3.0.12)
+
+**Merged pull requests:**
+
+- extend `node\_version` range on applicable tests [\#2015](https://github.com/mishoo/UglifyJS2/pull/2015) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v3.0.12 [\#2014](https://github.com/mishoo/UglifyJS2/pull/2014) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.12](https://github.com/mishoo/UglifyJS2/tree/v3.0.12) (2017-05-27)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.11...v3.0.12)
+
+**Merged pull requests:**
+
+- fix `hoist\_funs` on block-scoped `function` under "use strict" [\#2013](https://github.com/mishoo/UglifyJS2/pull/2013) ([alexlamsl](https://github.com/alexlamsl))
+- clarify what --mangle-props does [\#2012](https://github.com/mishoo/UglifyJS2/pull/2012) ([kzc](https://github.com/kzc))
+- fix `if\_return` on `AST\_Defun` [\#2010](https://github.com/mishoo/UglifyJS2/pull/2010) ([alexlamsl](https://github.com/alexlamsl))
+- better document mangle properties options [\#2009](https://github.com/mishoo/UglifyJS2/pull/2009) ([kzc](https://github.com/kzc))
+- fix and expand --mangle-props documentation [\#2008](https://github.com/mishoo/UglifyJS2/pull/2008) ([kzc](https://github.com/kzc))
+- fix `dead\_code` on block-scoped `function` under "use strict" [\#2006](https://github.com/mishoo/UglifyJS2/pull/2006) ([alexlamsl](https://github.com/alexlamsl))
+- fix `export` related issues [\#2005](https://github.com/mishoo/UglifyJS2/pull/2005) ([alexlamsl](https://github.com/alexlamsl))
+- clean up `lib/scope.js` [\#2003](https://github.com/mishoo/UglifyJS2/pull/2003) ([alexlamsl](https://github.com/alexlamsl))
+- fix issues related to `export` & `function` [\#2002](https://github.com/mishoo/UglifyJS2/pull/2002) ([alexlamsl](https://github.com/alexlamsl))
+- report timing breakdown [\#2000](https://github.com/mishoo/UglifyJS2/pull/2000) ([alexlamsl](https://github.com/alexlamsl))
+- ensure new line after `describe\_ast\(\)` [\#1999](https://github.com/mishoo/UglifyJS2/pull/1999) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] remove `AST\_ArrowParametersOrSeq` [\#1997](https://github.com/mishoo/UglifyJS2/pull/1997) ([alexlamsl](https://github.com/alexlamsl))
+- reinstate `describe\_ast\(\)` on CLI [\#1996](https://github.com/mishoo/UglifyJS2/pull/1996) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.11](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.11) (2017-05-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.11...harmony-v3.0.11)
+
+**Merged pull requests:**
+
+- Harmony v3.0.11 [\#1994](https://github.com/mishoo/UglifyJS2/pull/1994) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.11](https://github.com/mishoo/UglifyJS2/tree/v3.0.11) (2017-05-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.10...v3.0.11)
+
+**Merged pull requests:**
+
+- fix source map offset [\#1993](https://github.com/mishoo/UglifyJS2/pull/1993) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix destructuring bugs in mangle and compress [\#1992](https://github.com/mishoo/UglifyJS2/pull/1992) ([kzc](https://github.com/kzc))
+- \[ES6\] fix destructuring of non string keys [\#1989](https://github.com/mishoo/UglifyJS2/pull/1989) ([kzc](https://github.com/kzc))
+- add another minify\(\) options example [\#1988](https://github.com/mishoo/UglifyJS2/pull/1988) ([kzc](https://github.com/kzc))
+- improve usability of `global\_defs` in `minify\(\)` [\#1987](https://github.com/mishoo/UglifyJS2/pull/1987) ([alexlamsl](https://github.com/alexlamsl))
+- more refinement of minify\(\) documentation [\#1983](https://github.com/mishoo/UglifyJS2/pull/1983) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.10](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.10) (2017-05-20)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.10...harmony-v3.0.10)
+
+**Merged pull requests:**
+
+- Harmony v3.0.10 [\#1982](https://github.com/mishoo/UglifyJS2/pull/1982) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.10](https://github.com/mishoo/UglifyJS2/tree/v3.0.10) (2017-05-20)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.27...v3.0.10)
+
+**Merged pull requests:**
+
+- uglify-es: update keywords in package.json [\#1981](https://github.com/mishoo/UglifyJS2/pull/1981) ([kzc](https://github.com/kzc))
+- add "es5" to package.json keywords [\#1980](https://github.com/mishoo/UglifyJS2/pull/1980) ([kzc](https://github.com/kzc))
+- document minify\(\) option `toplevel` [\#1979](https://github.com/mishoo/UglifyJS2/pull/1979) ([kzc](https://github.com/kzc))
+- enhance `if\_return` to handle `return void...` [\#1977](https://github.com/mishoo/UglifyJS2/pull/1977) ([alexlamsl](https://github.com/alexlamsl))
+- fix parsing of `yield` as object key [\#1976](https://github.com/mishoo/UglifyJS2/pull/1976) ([alexlamsl](https://github.com/alexlamsl))
+- document 3.x minify\(\) does not throw errors [\#1975](https://github.com/mishoo/UglifyJS2/pull/1975) ([kzc](https://github.com/kzc))
+
+## [v2.8.27](https://github.com/mishoo/UglifyJS2/tree/v2.8.27) (2017-05-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.9...v2.8.27)
+
+**Merged pull requests:**
+
+- document minify `warnings` and add an error example [\#1973](https://github.com/mishoo/UglifyJS2/pull/1973) ([kzc](https://github.com/kzc))
+- backports for 2.8.27 [\#1971](https://github.com/mishoo/UglifyJS2/pull/1971) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.9](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.9) (2017-05-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.9...harmony-v3.0.9)
+
+**Merged pull requests:**
+
+- Harmony v3.0.9 [\#1972](https://github.com/mishoo/UglifyJS2/pull/1972) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.9](https://github.com/mishoo/UglifyJS2/tree/v3.0.9) (2017-05-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.8...v3.0.9)
+
+**Merged pull requests:**
+
+- introduce `unsafe\_regexp` [\#1970](https://github.com/mishoo/UglifyJS2/pull/1970) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] suppress `unused` on block variables [\#1969](https://github.com/mishoo/UglifyJS2/pull/1969) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.8](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.8) (2017-05-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.8...harmony-v3.0.8)
+
+**Merged pull requests:**
+
+- Harmony v3.0.8 [\#1967](https://github.com/mishoo/UglifyJS2/pull/1967) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.8](https://github.com/mishoo/UglifyJS2/tree/v3.0.8) (2017-05-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.7...v3.0.8)
+
+**Merged pull requests:**
+
+- fix docs for side\_effects flag to reflect current behavior [\#1966](https://github.com/mishoo/UglifyJS2/pull/1966) ([kara](https://github.com/kara))
+- make `expect\_stdout` node version specific [\#1963](https://github.com/mishoo/UglifyJS2/pull/1963) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] better extends paren fix [\#1962](https://github.com/mishoo/UglifyJS2/pull/1962) ([kzc](https://github.com/kzc))
+- remove `space\_colon` [\#1960](https://github.com/mishoo/UglifyJS2/pull/1960) ([alexlamsl](https://github.com/alexlamsl))
+- improve `RegExp` handling [\#1959](https://github.com/mishoo/UglifyJS2/pull/1959) ([alexlamsl](https://github.com/alexlamsl))
+- \[Docs\] update output options in readme [\#1958](https://github.com/mishoo/UglifyJS2/pull/1958) ([Mottie](https://github.com/Mottie))
+- \[ES6\] fix class extends expression [\#1956](https://github.com/mishoo/UglifyJS2/pull/1956) ([kzc](https://github.com/kzc))
+- \[ES6\] support export default of anonymous functions and classes [\#1954](https://github.com/mishoo/UglifyJS2/pull/1954) ([kzc](https://github.com/kzc))
+
+## [harmony-v3.0.7](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.7) (2017-05-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.7...harmony-v3.0.7)
+
+**Merged pull requests:**
+
+- Harmony v3.0.7 [\#1951](https://github.com/mishoo/UglifyJS2/pull/1951) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.7](https://github.com/mishoo/UglifyJS2/tree/v3.0.7) (2017-05-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.6...v3.0.7)
+
+**Merged pull requests:**
+
+-   export `TreeTransformer` [\#1950](https://github.com/mishoo/UglifyJS2/pull/1950) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.6](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.6) (2017-05-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.26...harmony-v3.0.6)
+
+**Merged pull requests:**
+
+- Harmony v3.0.6 [\#1948](https://github.com/mishoo/UglifyJS2/pull/1948) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.26](https://github.com/mishoo/UglifyJS2/tree/v2.8.26) (2017-05-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.6...v2.8.26)
+
+**Merged pull requests:**
+
+- backports for 2.8.26 [\#1947](https://github.com/mishoo/UglifyJS2/pull/1947) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.6](https://github.com/mishoo/UglifyJS2/tree/v3.0.6) (2017-05-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.5...v3.0.6)
+
+**Merged pull requests:**
+
+- print package name alongside version in CLI [\#1946](https://github.com/mishoo/UglifyJS2/pull/1946) ([alexlamsl](https://github.com/alexlamsl))
+- fix parsing of property access after new line [\#1944](https://github.com/mishoo/UglifyJS2/pull/1944) ([alexlamsl](https://github.com/alexlamsl))
+- reorg README for 3.x [\#1942](https://github.com/mishoo/UglifyJS2/pull/1942) ([kzc](https://github.com/kzc))
+- improve keyword-related parser errors [\#1941](https://github.com/mishoo/UglifyJS2/pull/1941) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.5](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.5) (2017-05-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.25...harmony-v3.0.5)
+
+**Merged pull requests:**
+
+- keep `minify\(\)` options in sync [\#1940](https://github.com/mishoo/UglifyJS2/pull/1940) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v3.0.5 [\#1939](https://github.com/mishoo/UglifyJS2/pull/1939) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.25](https://github.com/mishoo/UglifyJS2/tree/v2.8.25) (2017-05-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.5...v2.8.25)
+
+**Merged pull requests:**
+
+- backports for 2.8.25 [\#1938](https://github.com/mishoo/UglifyJS2/pull/1938) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.5](https://github.com/mishoo/UglifyJS2/tree/v3.0.5) (2017-05-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.24...v3.0.5)
+
+**Merged pull requests:**
+
+- fix & improve coverage of `estree` [\#1935](https://github.com/mishoo/UglifyJS2/pull/1935) ([alexlamsl](https://github.com/alexlamsl))
+- Tweak README Notes [\#1934](https://github.com/mishoo/UglifyJS2/pull/1934) ([kzc](https://github.com/kzc))
+- uglify-es: update homepage in package.json [\#1933](https://github.com/mishoo/UglifyJS2/pull/1933) ([kzc](https://github.com/kzc))
+- \[ES6\] fix `export default expression;` [\#1932](https://github.com/mishoo/UglifyJS2/pull/1932) ([kzc](https://github.com/kzc))
+- clarify wording [\#1931](https://github.com/mishoo/UglifyJS2/pull/1931) ([olsonpm](https://github.com/olsonpm))
+- document 3 max passes [\#1928](https://github.com/mishoo/UglifyJS2/pull/1928) ([olsonpm](https://github.com/olsonpm))
+- fix bugs with getter/setter [\#1926](https://github.com/mishoo/UglifyJS2/pull/1926) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.24](https://github.com/mishoo/UglifyJS2/tree/v2.8.24) (2017-05-12)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.4...v2.8.24)
+
+**Merged pull requests:**
+
+- add documentation for commit 1e51586 [\#1925](https://github.com/mishoo/UglifyJS2/pull/1925) ([olsonpm](https://github.com/olsonpm))
+- avoid `arguments` and `eval` in `reduce\_vars` [\#1924](https://github.com/mishoo/UglifyJS2/pull/1924) ([alexlamsl](https://github.com/alexlamsl))
+- backports for 2.8.24 [\#1921](https://github.com/mishoo/UglifyJS2/pull/1921) ([alexlamsl](https://github.com/alexlamsl))
+- remove support for `const` [\#1910](https://github.com/mishoo/UglifyJS2/pull/1910) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.4](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.4) (2017-05-11)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.4...harmony-v3.0.4)
+
+**Merged pull requests:**
+
+- Harmony v3.0.4 [\#1923](https://github.com/mishoo/UglifyJS2/pull/1923) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Make sure globals can be accessed from the browser [\#1920](https://github.com/mishoo/UglifyJS2/pull/1920) ([avdg](https://github.com/avdg))
+
+## [v3.0.4](https://github.com/mishoo/UglifyJS2/tree/v3.0.4) (2017-05-11)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.3...v3.0.4)
+
+**Merged pull requests:**
+
+- fix invalid transform on `const` [\#1919](https://github.com/mishoo/UglifyJS2/pull/1919) ([alexlamsl](https://github.com/alexlamsl))
+- update README [\#1918](https://github.com/mishoo/UglifyJS2/pull/1918) ([kzc](https://github.com/kzc))
+- document known issues with `const` [\#1916](https://github.com/mishoo/UglifyJS2/pull/1916) ([alexlamsl](https://github.com/alexlamsl))
+- fix typo [\#1913](https://github.com/mishoo/UglifyJS2/pull/1913) ([OmgImAlexis](https://github.com/OmgImAlexis))
+- update documentation [\#1909](https://github.com/mishoo/UglifyJS2/pull/1909) ([alexlamsl](https://github.com/alexlamsl))
+- \[2.x\] change `harmony` references to `uglify-es` in README [\#1902](https://github.com/mishoo/UglifyJS2/pull/1902) ([kzc](https://github.com/kzc))
+- \[ES6\] fix safari syntax error - declare twice [\#1851](https://github.com/mishoo/UglifyJS2/pull/1851) ([Perlmint](https://github.com/Perlmint))
+
+## [harmony-v3.0.3](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.3) (2017-05-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.3...harmony-v3.0.3)
+
+**Merged pull requests:**
+
+- Harmony v3.0.3 [\#1901](https://github.com/mishoo/UglifyJS2/pull/1901) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.3](https://github.com/mishoo/UglifyJS2/tree/v3.0.3) (2017-05-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.2...v3.0.3)
+
+**Merged pull requests:**
+
+- Update issue template: change harmony to uglify-es [\#1900](https://github.com/mishoo/UglifyJS2/pull/1900) ([kzc](https://github.com/kzc))
+- \[ES6\] fix for-of loop with const iterator [\#1899](https://github.com/mishoo/UglifyJS2/pull/1899) ([kzc](https://github.com/kzc))
+- Remove unnecessary `git clone` instructions in README [\#1897](https://github.com/mishoo/UglifyJS2/pull/1897) ([kzc](https://github.com/kzc))
+- Remove incorrect `git clone` instructions from `uglify-es` README [\#1896](https://github.com/mishoo/UglifyJS2/pull/1896) ([kzc](https://github.com/kzc))
+- Change `harmony` to `uglify-es` in master README [\#1895](https://github.com/mishoo/UglifyJS2/pull/1895) ([kzc](https://github.com/kzc))
+- Have harmony docs use `uglify-es` package name. [\#1894](https://github.com/mishoo/UglifyJS2/pull/1894) ([kzc](https://github.com/kzc))
+- gracefully handle non-`Error` being thrown [\#1893](https://github.com/mishoo/UglifyJS2/pull/1893) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.2](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.2) (2017-05-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.2...harmony-v3.0.2)
+
+**Merged pull requests:**
+
+- Harmony v3.0.2 [\#1892](https://github.com/mishoo/UglifyJS2/pull/1892) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.2](https://github.com/mishoo/UglifyJS2/tree/v3.0.2) (2017-05-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.1...v3.0.2)
+
+**Merged pull requests:**
+
+- print error stack in CLI [\#1890](https://github.com/mishoo/UglifyJS2/pull/1890) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `collapse\_vars` on destructuring declarations [\#1889](https://github.com/mishoo/UglifyJS2/pull/1889) ([alexlamsl](https://github.com/alexlamsl))
+- update `minify\(\)` usage in `test/ufuzz.js` [\#1888](https://github.com/mishoo/UglifyJS2/pull/1888) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.1](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.1) (2017-05-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.1...harmony-v3.0.1)
+
+**Merged pull requests:**
+
+- Harmony v3.0.1 [\#1885](https://github.com/mishoo/UglifyJS2/pull/1885) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix Unicode handling in parser [\#1884](https://github.com/mishoo/UglifyJS2/pull/1884) ([alexlamsl](https://github.com/alexlamsl))
+- \[3.x\] fix documentation for beautify options [\#1882](https://github.com/mishoo/UglifyJS2/pull/1882) ([kzc](https://github.com/kzc))
+
+## [v3.0.1](https://github.com/mishoo/UglifyJS2/tree/v3.0.1) (2017-05-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v3.0.0...v3.0.1)
+
+**Merged pull requests:**
+
+- return `Error` from `minify\(\)` [\#1880](https://github.com/mishoo/UglifyJS2/pull/1880) ([alexlamsl](https://github.com/alexlamsl))
+- support dumping AST [\#1879](https://github.com/mishoo/UglifyJS2/pull/1879) ([alexlamsl](https://github.com/alexlamsl))
+- support `minify\(\)` output as AST [\#1878](https://github.com/mishoo/UglifyJS2/pull/1878) ([alexlamsl](https://github.com/alexlamsl))
+- deprecate low level API [\#1877](https://github.com/mishoo/UglifyJS2/pull/1877) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v3.0.0](https://github.com/mishoo/UglifyJS2/tree/harmony-v3.0.0) (2017-05-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.23...harmony-v3.0.0)
+
+**Merged pull requests:**
+
+- Harmony v3.0.0 [\#1876](https://github.com/mishoo/UglifyJS2/pull/1876) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.23](https://github.com/mishoo/UglifyJS2/tree/v2.8.23) (2017-05-06)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v3.0.0...v2.8.23)
+
+**Merged pull requests:**
+
+- fix test for \#1865 [\#1873](https://github.com/mishoo/UglifyJS2/pull/1873) ([alexlamsl](https://github.com/alexlamsl))
+- backports for 2.8.23 [\#1871](https://github.com/mishoo/UglifyJS2/pull/1871) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v3.0.0](https://github.com/mishoo/UglifyJS2/tree/v3.0.0) (2017-05-06)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.22...v3.0.0)
+
+**Merged pull requests:**
+
+- fix `unsafe` on `evaluate` of `reduce\_vars` [\#1870](https://github.com/mishoo/UglifyJS2/pull/1870) ([alexlamsl](https://github.com/alexlamsl))
+- kill `opera` [\#1869](https://github.com/mishoo/UglifyJS2/pull/1869) ([alexlamsl](https://github.com/alexlamsl))
+- update `test/benchmark.js` resources [\#1864](https://github.com/mishoo/UglifyJS2/pull/1864) ([alexlamsl](https://github.com/alexlamsl))
+- rename variables for better readability [\#1863](https://github.com/mishoo/UglifyJS2/pull/1863) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `collapse\_vars` [\#1862](https://github.com/mishoo/UglifyJS2/pull/1862) ([alexlamsl](https://github.com/alexlamsl))
+- restore report of supported options [\#1861](https://github.com/mishoo/UglifyJS2/pull/1861) ([alexlamsl](https://github.com/alexlamsl))
+- improve return optimization for constant expressions [\#1860](https://github.com/mishoo/UglifyJS2/pull/1860) ([kzc](https://github.com/kzc))
+- \[ES6\] template string newline fix [\#1857](https://github.com/mishoo/UglifyJS2/pull/1857) ([kzc](https://github.com/kzc))
+- enforce `toplevel` on other compress options [\#1855](https://github.com/mishoo/UglifyJS2/pull/1855) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix class method formatting with `-b` [\#1853](https://github.com/mishoo/UglifyJS2/pull/1853) ([kzc](https://github.com/kzc))
+- Update ISSUE\_TEMPLATE.md [\#1846](https://github.com/mishoo/UglifyJS2/pull/1846) ([kzc](https://github.com/kzc))
+- fix `unused` on for-in statements [\#1843](https://github.com/mishoo/UglifyJS2/pull/1843) ([alexlamsl](https://github.com/alexlamsl))
+- fix fuzzer on `this` [\#1842](https://github.com/mishoo/UglifyJS2/pull/1842) ([alexlamsl](https://github.com/alexlamsl))
+- update README for 3.x [\#1840](https://github.com/mishoo/UglifyJS2/pull/1840) ([kzc](https://github.com/kzc))
+- fix `AST\_For.init` patch-up in `drop\_unused\(\)` [\#1839](https://github.com/mishoo/UglifyJS2/pull/1839) ([alexlamsl](https://github.com/alexlamsl))
+- improve parser under "use strict" [\#1836](https://github.com/mishoo/UglifyJS2/pull/1836) ([alexlamsl](https://github.com/alexlamsl))
+- fix label-related bugs [\#1835](https://github.com/mishoo/UglifyJS2/pull/1835) ([alexlamsl](https://github.com/alexlamsl))
+- Fix API reference examples [\#1834](https://github.com/mishoo/UglifyJS2/pull/1834) ([lahmatiy](https://github.com/lahmatiy))
+- improve `unused` [\#1832](https://github.com/mishoo/UglifyJS2/pull/1832) ([alexlamsl](https://github.com/alexlamsl))
+- fix `unused` on labeled for-loop [\#1831](https://github.com/mishoo/UglifyJS2/pull/1831) ([alexlamsl](https://github.com/alexlamsl))
+- extend `cascade` into `a.b` [\#1829](https://github.com/mishoo/UglifyJS2/pull/1829) ([alexlamsl](https://github.com/alexlamsl))
+- improve `collapse\_vars` on `AST\_Var` [\#1828](https://github.com/mishoo/UglifyJS2/pull/1828) ([alexlamsl](https://github.com/alexlamsl))
+- fix parser bugs & CLI reporting [\#1827](https://github.com/mishoo/UglifyJS2/pull/1827) ([alexlamsl](https://github.com/alexlamsl))
+- clean up `collapse\_vars` [\#1826](https://github.com/mishoo/UglifyJS2/pull/1826) ([alexlamsl](https://github.com/alexlamsl))
+- support safe reassignments in `reduce\_vars` [\#1823](https://github.com/mishoo/UglifyJS2/pull/1823) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on conditionals [\#1822](https://github.com/mishoo/UglifyJS2/pull/1822) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on boolean binary expressions [\#1819](https://github.com/mishoo/UglifyJS2/pull/1819) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` within try-block [\#1818](https://github.com/mishoo/UglifyJS2/pull/1818) ([alexlamsl](https://github.com/alexlamsl))
+- compress duplicated variable definitions [\#1817](https://github.com/mishoo/UglifyJS2/pull/1817) ([alexlamsl](https://github.com/alexlamsl))
+- fix variable substitution [\#1816](https://github.com/mishoo/UglifyJS2/pull/1816) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `reduce\_vars` [\#1814](https://github.com/mishoo/UglifyJS2/pull/1814) ([alexlamsl](https://github.com/alexlamsl))
+- update README [\#1813](https://github.com/mishoo/UglifyJS2/pull/1813) ([alexlamsl](https://github.com/alexlamsl))
+- drop `angular` [\#1812](https://github.com/mishoo/UglifyJS2/pull/1812) ([alexlamsl](https://github.com/alexlamsl))
+- unify CLI & API under `minify\(\)` [\#1811](https://github.com/mishoo/UglifyJS2/pull/1811) ([alexlamsl](https://github.com/alexlamsl))
+- \[3.x\] convert AST\_Seq from binary tree to array [\#1460](https://github.com/mishoo/UglifyJS2/pull/1460) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.22](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.22) (2017-04-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.22...harmony-v2.8.22)
+
+**Merged pull requests:**
+
+- Harmony v2.8.22 [\#1805](https://github.com/mishoo/UglifyJS2/pull/1805) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.22](https://github.com/mishoo/UglifyJS2/tree/v2.8.22) (2017-04-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.21...v2.8.22)
+
+**Merged pull requests:**
+
+- fix LHS cases for NaN & friends [\#1804](https://github.com/mishoo/UglifyJS2/pull/1804) ([alexlamsl](https://github.com/alexlamsl))
+- enhance `test/ufuzz.js` [\#1803](https://github.com/mishoo/UglifyJS2/pull/1803) ([alexlamsl](https://github.com/alexlamsl))
+- fix a couple of bugs in `global\_defs` [\#1802](https://github.com/mishoo/UglifyJS2/pull/1802) ([alexlamsl](https://github.com/alexlamsl))
+- fix `delete` corner cases [\#1799](https://github.com/mishoo/UglifyJS2/pull/1799) ([alexlamsl](https://github.com/alexlamsl))
+- fix `pure\_getters` for chained property access [\#1798](https://github.com/mishoo/UglifyJS2/pull/1798) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner cases with `delete` [\#1796](https://github.com/mishoo/UglifyJS2/pull/1796) ([alexlamsl](https://github.com/alexlamsl))
+- introduce "strict" to `pure\_getters` [\#1795](https://github.com/mishoo/UglifyJS2/pull/1795) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on catch variable [\#1794](https://github.com/mishoo/UglifyJS2/pull/1794) ([alexlamsl](https://github.com/alexlamsl))
+- enable `inline\_script` by default [\#1793](https://github.com/mishoo/UglifyJS2/pull/1793) ([alexlamsl](https://github.com/alexlamsl))
+- fix incorrect context in variable substitution [\#1791](https://github.com/mishoo/UglifyJS2/pull/1791) ([alexlamsl](https://github.com/alexlamsl))
+- implement delayed resolution for `reduce\_vars` [\#1788](https://github.com/mishoo/UglifyJS2/pull/1788) ([alexlamsl](https://github.com/alexlamsl))
+- improve `pure\_getters` [\#1786](https://github.com/mishoo/UglifyJS2/pull/1786) ([alexlamsl](https://github.com/alexlamsl))
+- optimise `do{...}while\(false\)` [\#1785](https://github.com/mishoo/UglifyJS2/pull/1785) ([alexlamsl](https://github.com/alexlamsl))
+- extend ufuzz generator [\#1783](https://github.com/mishoo/UglifyJS2/pull/1783) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Put expression after extend between parentheses if necessary [\#1780](https://github.com/mishoo/UglifyJS2/pull/1780) ([avdg](https://github.com/avdg))
+- exclude mangling of special property names [\#1779](https://github.com/mishoo/UglifyJS2/pull/1779) ([alexlamsl](https://github.com/alexlamsl))
+- Allow AST\_DefaultAssign as parameter [\#1778](https://github.com/mishoo/UglifyJS2/pull/1778) ([avdg](https://github.com/avdg))
+- remove `--mangle-props` from fuzzing [\#1777](https://github.com/mishoo/UglifyJS2/pull/1777) ([alexlamsl](https://github.com/alexlamsl))
+- fix `mangleProperties` on identifiers [\#1776](https://github.com/mishoo/UglifyJS2/pull/1776) ([alexlamsl](https://github.com/alexlamsl))
+- workaround Node.js bugs [\#1775](https://github.com/mishoo/UglifyJS2/pull/1775) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Allow empty destructuring as function parameter [\#1773](https://github.com/mishoo/UglifyJS2/pull/1773) ([avdg](https://github.com/avdg))
+- fix mangleProperties of `undefined` & `Infinity` [\#1772](https://github.com/mishoo/UglifyJS2/pull/1772) ([alexlamsl](https://github.com/alexlamsl))
+- extend `test/ufuzz.js` [\#1769](https://github.com/mishoo/UglifyJS2/pull/1769) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Fix walker not able to handle destr pattern in spread when compressing [\#1438](https://github.com/mishoo/UglifyJS2/pull/1438) ([avdg](https://github.com/avdg))
+
+## [harmony-v2.8.21](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.21) (2017-04-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.21...harmony-v2.8.21)
+
+**Merged pull requests:**
+
+- Harmony v2.8.21 [\#1766](https://github.com/mishoo/UglifyJS2/pull/1766) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.21](https://github.com/mishoo/UglifyJS2/tree/v2.8.21) (2017-04-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.20...v2.8.21)
+
+**Merged pull requests:**
+
+- fix corner case in `switch` [\#1765](https://github.com/mishoo/UglifyJS2/pull/1765) ([alexlamsl](https://github.com/alexlamsl))
+- avoid confusion of `NaN` & `Infinity` with `catch` symbol of the same name [\#1763](https://github.com/mishoo/UglifyJS2/pull/1763) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner cases in switch and undefined [\#1762](https://github.com/mishoo/UglifyJS2/pull/1762) ([alexlamsl](https://github.com/alexlamsl))
+- speed up fuzzer code generation [\#1757](https://github.com/mishoo/UglifyJS2/pull/1757) ([alexlamsl](https://github.com/alexlamsl))
+- minor tweaks to `test/ufuzz.js` [\#1756](https://github.com/mishoo/UglifyJS2/pull/1756) ([alexlamsl](https://github.com/alexlamsl))
+- fuzz regexp literals, more constant numbers, typeof expression [\#1755](https://github.com/mishoo/UglifyJS2/pull/1755) ([kzc](https://github.com/kzc))
+- upgrade fuzzer [\#1754](https://github.com/mishoo/UglifyJS2/pull/1754) ([alexlamsl](https://github.com/alexlamsl))
+- fix switch branch elimination [\#1752](https://github.com/mishoo/UglifyJS2/pull/1752) ([alexlamsl](https://github.com/alexlamsl))
+- minor tweaks to fuzzer [\#1751](https://github.com/mishoo/UglifyJS2/pull/1751) ([alexlamsl](https://github.com/alexlamsl))
+- implement `test/sandbox.js` [\#1749](https://github.com/mishoo/UglifyJS2/pull/1749) ([alexlamsl](https://github.com/alexlamsl))
+- improve compression of undefined, NaN & Infinitiy [\#1748](https://github.com/mishoo/UglifyJS2/pull/1748) ([alexlamsl](https://github.com/alexlamsl))
+- combine rules for binary boolean operations [\#1744](https://github.com/mishoo/UglifyJS2/pull/1744) ([alexlamsl](https://github.com/alexlamsl))
+- sort options in alphabetical order [\#1743](https://github.com/mishoo/UglifyJS2/pull/1743) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Another variant of import added - import \* from "x.js" [\#1738](https://github.com/mishoo/UglifyJS2/pull/1738) ([OndrejSpanel](https://github.com/OndrejSpanel))
+- \[ES6\] Another variant of export added - export {Name}. [\#1737](https://github.com/mishoo/UglifyJS2/pull/1737) ([OndrejSpanel](https://github.com/OndrejSpanel))
+- Fuzz v3 [\#1697](https://github.com/mishoo/UglifyJS2/pull/1697) ([pvdz](https://github.com/pvdz))
+
+## [v2.8.20](https://github.com/mishoo/UglifyJS2/tree/v2.8.20) (2017-03-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.19...v2.8.20)
+
+**Merged pull requests:**
+
+- fix missing preamble when shebang is absent [\#1742](https://github.com/mishoo/UglifyJS2/pull/1742) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.19](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.19) (2017-03-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.19...harmony-v2.8.19)
+
+**Merged pull requests:**
+
+- Harmony v2.8.19 [\#1740](https://github.com/mishoo/UglifyJS2/pull/1740) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.19](https://github.com/mishoo/UglifyJS2/tree/v2.8.19) (2017-03-31)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.17...v2.8.19)
+
+**Merged pull requests:**
+
+- fix catch symbol mangling [\#1734](https://github.com/mishoo/UglifyJS2/pull/1734) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.17](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.17) (2017-03-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.18...harmony-v2.8.17)
+
+**Merged pull requests:**
+
+- remove paranthesis for `-\(x\*y\)` [\#1732](https://github.com/mishoo/UglifyJS2/pull/1732) ([alexlamsl](https://github.com/alexlamsl))
+- optimize try-catch-finally [\#1731](https://github.com/mishoo/UglifyJS2/pull/1731) ([alexlamsl](https://github.com/alexlamsl))
+- improve tests from \#1726 [\#1729](https://github.com/mishoo/UglifyJS2/pull/1729) ([alexlamsl](https://github.com/alexlamsl))
+- speed up IIFE elimination [\#1728](https://github.com/mishoo/UglifyJS2/pull/1728) ([alexlamsl](https://github.com/alexlamsl))
+- speed up `equivalent\_to\(\)` and `AST\_Switch` [\#1727](https://github.com/mishoo/UglifyJS2/pull/1727) ([alexlamsl](https://github.com/alexlamsl))
+- fix missing parentheses around NaN/Infinity shorthands [\#1726](https://github.com/mishoo/UglifyJS2/pull/1726) ([alexlamsl](https://github.com/alexlamsl))
+- output optimal representations of NaN & Infinity [\#1723](https://github.com/mishoo/UglifyJS2/pull/1723) ([alexlamsl](https://github.com/alexlamsl))
+- improve beautified output of switch blocks [\#1721](https://github.com/mishoo/UglifyJS2/pull/1721) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Implemented parse for export Name from Module variants. [\#1701](https://github.com/mishoo/UglifyJS2/pull/1701) ([OndrejSpanel](https://github.com/OndrejSpanel))
+
+## [v2.8.18](https://github.com/mishoo/UglifyJS2/tree/v2.8.18) (2017-03-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.17...v2.8.18)
+
+**Merged pull requests:**
+
+- remove UGLIFY\_DEBUG [\#1720](https://github.com/mishoo/UglifyJS2/pull/1720) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `unused` [\#1718](https://github.com/mishoo/UglifyJS2/pull/1718) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v2.8.17 [\#1717](https://github.com/mishoo/UglifyJS2/pull/1717) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.17](https://github.com/mishoo/UglifyJS2/tree/v2.8.17) (2017-03-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.16...v2.8.17)
+
+**Merged pull requests:**
+
+- fix `unused` on var of the same name within catch [\#1716](https://github.com/mishoo/UglifyJS2/pull/1716) ([alexlamsl](https://github.com/alexlamsl))
+- fix `is\_number\(\)` on `+=` [\#1714](https://github.com/mishoo/UglifyJS2/pull/1714) ([alexlamsl](https://github.com/alexlamsl))
+- drop anonymous function name when overshadowed by other declarations [\#1712](https://github.com/mishoo/UglifyJS2/pull/1712) ([alexlamsl](https://github.com/alexlamsl))
+- handle var within catch of the same name [\#1711](https://github.com/mishoo/UglifyJS2/pull/1711) ([alexlamsl](https://github.com/alexlamsl))
+- fix tail trimming of switch blocks [\#1707](https://github.com/mishoo/UglifyJS2/pull/1707) ([alexlamsl](https://github.com/alexlamsl))
+- fix mangle for variable declared within catch block [\#1706](https://github.com/mishoo/UglifyJS2/pull/1706) ([alexlamsl](https://github.com/alexlamsl))
+- ufuzz: workaround for Function.toString\(\) v2 [\#1700](https://github.com/mishoo/UglifyJS2/pull/1700) ([alexlamsl](https://github.com/alexlamsl))
+- `has\_side\_effects\(\)` should take `AST\_Switch.expression` into account [\#1699](https://github.com/mishoo/UglifyJS2/pull/1699) ([alexlamsl](https://github.com/alexlamsl))
+- fix typeof side effects [\#1696](https://github.com/mishoo/UglifyJS2/pull/1696) ([alexlamsl](https://github.com/alexlamsl))
+- preserve side effects in switch expression [\#1694](https://github.com/mishoo/UglifyJS2/pull/1694) ([alexlamsl](https://github.com/alexlamsl))
+- fix `cascade` on anonymous function reference [\#1693](https://github.com/mishoo/UglifyJS2/pull/1693) ([alexlamsl](https://github.com/alexlamsl))
+- handle overlapped variable definitions [\#1691](https://github.com/mishoo/UglifyJS2/pull/1691) ([alexlamsl](https://github.com/alexlamsl))
+- fix `delete` related issues in `collapse\_vars` and `reduce\_vars` [\#1689](https://github.com/mishoo/UglifyJS2/pull/1689) ([alexlamsl](https://github.com/alexlamsl))
+- ufuzz: workaround function name and toString\(\) [\#1688](https://github.com/mishoo/UglifyJS2/pull/1688) ([alexlamsl](https://github.com/alexlamsl))
+- fix `cascade` on `delete` operator [\#1687](https://github.com/mishoo/UglifyJS2/pull/1687) ([alexlamsl](https://github.com/alexlamsl))
+- optimize conditional when condition symbol matches consequent [\#1684](https://github.com/mishoo/UglifyJS2/pull/1684) ([kzc](https://github.com/kzc))
+- fallthrough should not execute case expression [\#1683](https://github.com/mishoo/UglifyJS2/pull/1683) ([alexlamsl](https://github.com/alexlamsl))
+- suppress switch branch de-duplication upon side effects [\#1682](https://github.com/mishoo/UglifyJS2/pull/1682) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] optimize trivial arrow functions with a return statement in braces [\#1681](https://github.com/mishoo/UglifyJS2/pull/1681) ([kzc](https://github.com/kzc))
+- fix side-effects detection on switch statements [\#1678](https://github.com/mishoo/UglifyJS2/pull/1678) ([alexlamsl](https://github.com/alexlamsl))
+- improve switch optimisations [\#1677](https://github.com/mishoo/UglifyJS2/pull/1677) ([alexlamsl](https://github.com/alexlamsl))
+- fix `has\_side\_effects\(\)` [\#1675](https://github.com/mishoo/UglifyJS2/pull/1675) ([alexlamsl](https://github.com/alexlamsl))
+- fix `reduce\_vars` on `AST\_Switch` [\#1671](https://github.com/mishoo/UglifyJS2/pull/1671) ([alexlamsl](https://github.com/alexlamsl))
+- fix typeof side-effects [\#1669](https://github.com/mishoo/UglifyJS2/pull/1669) ([alexlamsl](https://github.com/alexlamsl))
+- fix `dead\_code` on `AST\_Switch` [\#1667](https://github.com/mishoo/UglifyJS2/pull/1667) ([alexlamsl](https://github.com/alexlamsl))
+- Improve fuzzer [\#1665](https://github.com/mishoo/UglifyJS2/pull/1665) ([pvdz](https://github.com/pvdz))
+
+## [v2.8.16](https://github.com/mishoo/UglifyJS2/tree/v2.8.16) (2017-03-24)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.15...v2.8.16)
+
+**Merged pull requests:**
+
+- fix invalid `AST\_For.init` [\#1657](https://github.com/mishoo/UglifyJS2/pull/1657) ([alexlamsl](https://github.com/alexlamsl))
+- introduce ufuzz.js [\#1655](https://github.com/mishoo/UglifyJS2/pull/1655) ([alexlamsl](https://github.com/alexlamsl))
+- fix cascade of `evaluate` optimisation [\#1654](https://github.com/mishoo/UglifyJS2/pull/1654) ([alexlamsl](https://github.com/alexlamsl))
+- fix corner case in `AST\_For.init` [\#1652](https://github.com/mishoo/UglifyJS2/pull/1652) ([alexlamsl](https://github.com/alexlamsl))
+- fix assignment extraction from conditional [\#1651](https://github.com/mishoo/UglifyJS2/pull/1651) ([alexlamsl](https://github.com/alexlamsl))
+- improve error marker placement [\#1644](https://github.com/mishoo/UglifyJS2/pull/1644) ([alexlamsl](https://github.com/alexlamsl))
+- fix assignment substitution in sequences [\#1643](https://github.com/mishoo/UglifyJS2/pull/1643) ([alexlamsl](https://github.com/alexlamsl))
+- fix expect\_stdout [\#1642](https://github.com/mishoo/UglifyJS2/pull/1642) ([alexlamsl](https://github.com/alexlamsl))
+- fix regression to allow CLI options with hyphens like -b ascii-only [\#1640](https://github.com/mishoo/UglifyJS2/pull/1640) ([kzc](https://github.com/kzc))
+- improve collapsible value detection [\#1638](https://github.com/mishoo/UglifyJS2/pull/1638) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.15](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.15) (2017-03-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.15...harmony-v2.8.15)
+
+**Merged pull requests:**
+
+- Harmony v2.8.15 [\#1636](https://github.com/mishoo/UglifyJS2/pull/1636) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.15](https://github.com/mishoo/UglifyJS2/tree/v2.8.15) (2017-03-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.14...v2.8.15)
+
+**Merged pull requests:**
+
+- account for cross-scope modifications in `collapse\_vars` [\#1634](https://github.com/mishoo/UglifyJS2/pull/1634) ([alexlamsl](https://github.com/alexlamsl))
+- suppress unused warnings from inlined elements [\#1633](https://github.com/mishoo/UglifyJS2/pull/1633) ([alexlamsl](https://github.com/alexlamsl))
+- fix a bug in simple\_glob [\#1632](https://github.com/mishoo/UglifyJS2/pull/1632) ([alexlamsl](https://github.com/alexlamsl))
+- metadata cleanup [\#1630](https://github.com/mishoo/UglifyJS2/pull/1630) ([alexlamsl](https://github.com/alexlamsl))
+- throw parse error on invalid assignments [\#1627](https://github.com/mishoo/UglifyJS2/pull/1627) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.14](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.14) (2017-03-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.14...harmony-v2.8.14)
+
+**Merged pull requests:**
+
+- Harmony v2.8.14 [\#1624](https://github.com/mishoo/UglifyJS2/pull/1624) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.14](https://github.com/mishoo/UglifyJS2/tree/v2.8.14) (2017-03-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.13...v2.8.14)
+
+**Merged pull requests:**
+
+- make `expect\_stdout` work on Node.js 0.12 [\#1623](https://github.com/mishoo/UglifyJS2/pull/1623) ([alexlamsl](https://github.com/alexlamsl))
+- fix commit 88fb83aa [\#1622](https://github.com/mishoo/UglifyJS2/pull/1622) ([alexlamsl](https://github.com/alexlamsl))
+- fix AST\_Binary.lift\_sequences\(\) [\#1621](https://github.com/mishoo/UglifyJS2/pull/1621) ([alexlamsl](https://github.com/alexlamsl))
+- transform String.charAt\(\) to index access [\#1620](https://github.com/mishoo/UglifyJS2/pull/1620) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.13](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.13) (2017-03-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.13...harmony-v2.8.13)
+
+**Merged pull requests:**
+
+- handle runtime errors in `expect\_stdout` [\#1618](https://github.com/mishoo/UglifyJS2/pull/1618) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Allow 'name' as object literal shorthand property \(closes \#1613\) [\#1617](https://github.com/mishoo/UglifyJS2/pull/1617) ([alexzaworski](https://github.com/alexzaworski))
+- fix top-level directives in compress tests [\#1615](https://github.com/mishoo/UglifyJS2/pull/1615) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v2.8.13 [\#1614](https://github.com/mishoo/UglifyJS2/pull/1614) ([alexlamsl](https://github.com/alexlamsl))
+- Add `--in-source-map inline` documentation [\#1611](https://github.com/mishoo/UglifyJS2/pull/1611) ([CMTegner](https://github.com/CMTegner))
+
+## [v2.8.13](https://github.com/mishoo/UglifyJS2/tree/v2.8.13) (2017-03-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.12...v2.8.13)
+
+**Merged pull requests:**
+
+- fix chained evaluation [\#1610](https://github.com/mishoo/UglifyJS2/pull/1610) ([alexlamsl](https://github.com/alexlamsl))
+- make `collapse\_vars` consistent with `toplevel` [\#1608](https://github.com/mishoo/UglifyJS2/pull/1608) ([alexlamsl](https://github.com/alexlamsl))
+- fix `hoist\_vars` on `reduce\_vars` [\#1607](https://github.com/mishoo/UglifyJS2/pull/1607) ([alexlamsl](https://github.com/alexlamsl))
+- extend `test/run-tests.js` to optionally execute uglified output [\#1604](https://github.com/mishoo/UglifyJS2/pull/1604) ([alexlamsl](https://github.com/alexlamsl))
+- fix stack issues with `AST\_Node.evaluate\(\)` [\#1603](https://github.com/mishoo/UglifyJS2/pull/1603) ([alexlamsl](https://github.com/alexlamsl))
+- fix `AST\_Node.optimize\(\)` [\#1602](https://github.com/mishoo/UglifyJS2/pull/1602) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.12](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.12) (2017-03-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.12...harmony-v2.8.12)
+
+**Merged pull requests:**
+
+- Harmony v2.8.12 [\#1601](https://github.com/mishoo/UglifyJS2/pull/1601) ([alexlamsl](https://github.com/alexlamsl))
+- minor clean-ups [\#1600](https://github.com/mishoo/UglifyJS2/pull/1600) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] fix `unused` crashes [\#1599](https://github.com/mishoo/UglifyJS2/pull/1599) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.12](https://github.com/mishoo/UglifyJS2/tree/v2.8.12) (2017-03-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.11...v2.8.12)
+
+**Merged pull requests:**
+
+- temporary fix for boolean bug [\#1597](https://github.com/mishoo/UglifyJS2/pull/1597) ([alexlamsl](https://github.com/alexlamsl))
+- disallow parameter substitution for named IIFEs [\#1596](https://github.com/mishoo/UglifyJS2/pull/1596) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.11](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.11) (2017-03-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.11...harmony-v2.8.11)
+
+**Merged pull requests:**
+
+- Harmony v2.8.11 [\#1591](https://github.com/mishoo/UglifyJS2/pull/1591) ([alexlamsl](https://github.com/alexlamsl))
+- support multi-line string in tests [\#1590](https://github.com/mishoo/UglifyJS2/pull/1590) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.11](https://github.com/mishoo/UglifyJS2/tree/v2.8.11) (2017-03-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.10...v2.8.11)
+
+**Merged pull requests:**
+
+- fixup for \#1585 [\#1589](https://github.com/mishoo/UglifyJS2/pull/1589) ([alexlamsl](https://github.com/alexlamsl))
+- fix catch variable reference in IE8 [\#1587](https://github.com/mishoo/UglifyJS2/pull/1587) ([alexlamsl](https://github.com/alexlamsl))
+- Correctly raise parse error on missing loop body [\#1585](https://github.com/mishoo/UglifyJS2/pull/1585) ([michaelmior](https://github.com/michaelmior))
+- fix & improve function argument compression [\#1584](https://github.com/mishoo/UglifyJS2/pull/1584) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v2.8.10 [\#1582](https://github.com/mishoo/UglifyJS2/pull/1582) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.10](https://github.com/mishoo/UglifyJS2/tree/v2.8.10) (2017-03-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.10...v2.8.10)
+
+## [harmony-v2.8.10](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.10) (2017-03-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.9...harmony-v2.8.10)
+
+**Merged pull requests:**
+
+- scan RHS of dropped assignments [\#1581](https://github.com/mishoo/UglifyJS2/pull/1581) ([alexlamsl](https://github.com/alexlamsl))
+- explain how to make a proper bug report [\#1579](https://github.com/mishoo/UglifyJS2/pull/1579) ([alexlamsl](https://github.com/alexlamsl))
+- scan assignment value in drop\_unused\(\) [\#1578](https://github.com/mishoo/UglifyJS2/pull/1578) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.9](https://github.com/mishoo/UglifyJS2/tree/v2.8.9) (2017-03-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.8...v2.8.9)
+
+**Merged pull requests:**
+
+- fix function name eliminiation [\#1576](https://github.com/mishoo/UglifyJS2/pull/1576) ([alexlamsl](https://github.com/alexlamsl))
+- plan B for IE8 do-while semi-colon fix [\#1572](https://github.com/mishoo/UglifyJS2/pull/1572) ([alexlamsl](https://github.com/alexlamsl))
+- only run benchmark & jetstream on CI [\#1571](https://github.com/mishoo/UglifyJS2/pull/1571) ([alexlamsl](https://github.com/alexlamsl))
+- fix return from recursive IIFE [\#1570](https://github.com/mishoo/UglifyJS2/pull/1570) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v2.8.8 [\#1567](https://github.com/mishoo/UglifyJS2/pull/1567) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v2.8.8 [\#1566](https://github.com/mishoo/UglifyJS2/pull/1566) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] AST\_IterationStatement always define a new scope [\#1561](https://github.com/mishoo/UglifyJS2/pull/1561) ([qinayi](https://github.com/qinayi))
+
+## [v2.8.8](https://github.com/mishoo/UglifyJS2/tree/v2.8.8) (2017-03-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.7...v2.8.8)
+
+**Merged pull requests:**
+
+- fix deep cloning of labels [\#1565](https://github.com/mishoo/UglifyJS2/pull/1565) ([alexlamsl](https://github.com/alexlamsl))
+- include benchmark.js in test suite [\#1564](https://github.com/mishoo/UglifyJS2/pull/1564) ([alexlamsl](https://github.com/alexlamsl))
+- collapse\_vars: do not replace a constant in loop condition or init [\#1562](https://github.com/mishoo/UglifyJS2/pull/1562) ([kzc](https://github.com/kzc))
+- transform function calls to IIFEs [\#1560](https://github.com/mishoo/UglifyJS2/pull/1560) ([alexlamsl](https://github.com/alexlamsl))
+- avoid substitution of global variables [\#1557](https://github.com/mishoo/UglifyJS2/pull/1557) ([alexlamsl](https://github.com/alexlamsl))
+- suppress semicolons after do/while [\#1556](https://github.com/mishoo/UglifyJS2/pull/1556) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.7](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.7) (2017-03-05)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.7...harmony-v2.8.7)
+
+**Merged pull requests:**
+
+- Harmony v2.8.7 [\#1554](https://github.com/mishoo/UglifyJS2/pull/1554) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.7](https://github.com/mishoo/UglifyJS2/tree/v2.8.7) (2017-03-05)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.6...v2.8.7)
+
+**Merged pull requests:**
+
+- fixup for \#1553 [\#1555](https://github.com/mishoo/UglifyJS2/pull/1555) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.6](https://github.com/mishoo/UglifyJS2/tree/v2.8.6) (2017-03-05)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.5...v2.8.6)
+
+**Merged pull requests:**
+
+- collapse assignment with adjacent subsequent usage [\#1553](https://github.com/mishoo/UglifyJS2/pull/1553) ([alexlamsl](https://github.com/alexlamsl))
+- fix a corner case in \#1530 [\#1552](https://github.com/mishoo/UglifyJS2/pull/1552) ([alexlamsl](https://github.com/alexlamsl))
+- resolve issue with outdated version of async [\#1549](https://github.com/mishoo/UglifyJS2/pull/1549) ([alexlamsl](https://github.com/alexlamsl))
+- improve `unsafe` on undefined [\#1548](https://github.com/mishoo/UglifyJS2/pull/1548) ([alexlamsl](https://github.com/alexlamsl))
+- stay safe with constants in IE8- [\#1547](https://github.com/mishoo/UglifyJS2/pull/1547) ([alexlamsl](https://github.com/alexlamsl))
+- handle variable declaration within catch blocks [\#1546](https://github.com/mishoo/UglifyJS2/pull/1546) ([alexlamsl](https://github.com/alexlamsl))
+- fix handling of shebang and preamble [\#1545](https://github.com/mishoo/UglifyJS2/pull/1545) ([alexlamsl](https://github.com/alexlamsl))
+- disallow collapse\_vars constant replacement in for-in statements [\#1543](https://github.com/mishoo/UglifyJS2/pull/1543) ([kzc](https://github.com/kzc))
+- preserve implicit return values [\#1522](https://github.com/mishoo/UglifyJS2/pull/1522) ([alexlamsl](https://github.com/alexlamsl))
+- compress numerical expressions [\#1513](https://github.com/mishoo/UglifyJS2/pull/1513) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.5](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.5) (2017-03-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.5...harmony-v2.8.5)
+
+**Merged pull requests:**
+
+- facilitate fix for \#1531 [\#1542](https://github.com/mishoo/UglifyJS2/pull/1542) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony v2.8.5 [\#1541](https://github.com/mishoo/UglifyJS2/pull/1541) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.5](https://github.com/mishoo/UglifyJS2/tree/v2.8.5) (2017-03-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.4...v2.8.5)
+
+**Merged pull requests:**
+
+- fix chained assignment with `unused` [\#1540](https://github.com/mishoo/UglifyJS2/pull/1540) ([alexlamsl](https://github.com/alexlamsl))
+- collapse\_vars should not replace constant in for-in init section [\#1538](https://github.com/mishoo/UglifyJS2/pull/1538) ([kzc](https://github.com/kzc))
+- properly cover all cases of for-in loop variables [\#1536](https://github.com/mishoo/UglifyJS2/pull/1536) ([alexlamsl](https://github.com/alexlamsl))
+- fix reference marking in for-in loops [\#1535](https://github.com/mishoo/UglifyJS2/pull/1535) ([alexlamsl](https://github.com/alexlamsl))
+- disable do{...}while\(false\) optimisation [\#1534](https://github.com/mishoo/UglifyJS2/pull/1534) ([alexlamsl](https://github.com/alexlamsl))
+- optimize trivial IIFEs returning constants [\#1530](https://github.com/mishoo/UglifyJS2/pull/1530) ([kzc](https://github.com/kzc))
+- trim unused invocation parameters [\#1526](https://github.com/mishoo/UglifyJS2/pull/1526) ([alexlamsl](https://github.com/alexlamsl))
+- minor improvement to string optimisation [\#1514](https://github.com/mishoo/UglifyJS2/pull/1514) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.4](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.4) (2017-03-02)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.4...harmony-v2.8.4)
+
+**Merged pull requests:**
+
+- Harmony v2.8.4 [\#1528](https://github.com/mishoo/UglifyJS2/pull/1528) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.4](https://github.com/mishoo/UglifyJS2/tree/v2.8.4) (2017-03-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.3...v2.8.4)
+
+**Merged pull requests:**
+
+- fix corner cases in `reduce\_vars` [\#1524](https://github.com/mishoo/UglifyJS2/pull/1524) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.3](https://github.com/mishoo/UglifyJS2/tree/v2.8.3) (2017-03-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.2...v2.8.3)
+
+**Merged pull requests:**
+
+- fix crash on missing `props` to `string\_template\(\)` [\#1523](https://github.com/mishoo/UglifyJS2/pull/1523) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.2](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.2) (2017-03-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.2...harmony-v2.8.2)
+
+**Merged pull requests:**
+
+- Harmony v2.8.2 [\#1521](https://github.com/mishoo/UglifyJS2/pull/1521) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.2](https://github.com/mishoo/UglifyJS2/tree/v2.8.2) (2017-02-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.1...v2.8.2)
+
+**Merged pull requests:**
+
+- invert `reduce\_vars` tracking flag [\#1519](https://github.com/mishoo/UglifyJS2/pull/1519) ([alexlamsl](https://github.com/alexlamsl))
+- fix `evaluate` on object getter & setter [\#1515](https://github.com/mishoo/UglifyJS2/pull/1515) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.1](https://github.com/mishoo/UglifyJS2/tree/v2.8.1) (2017-02-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.8.0...v2.8.1)
+
+**Merged pull requests:**
+
+- temporarily disables `reduce\_vars` as we investigate \#1516 [\#1517](https://github.com/mishoo/UglifyJS2/pull/1517) ([alexlamsl](https://github.com/alexlamsl))
+
+## [harmony-v2.8.0](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.8.0) (2017-02-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.8.0...harmony-v2.8.0)
+
+**Merged pull requests:**
+
+- warn & drop `\#\_\_PURE\_\_` iff IIFE is dropped [\#1511](https://github.com/mishoo/UglifyJS2/pull/1511) ([alexlamsl](https://github.com/alexlamsl))
+- Harmony 2.8.0 [\#1509](https://github.com/mishoo/UglifyJS2/pull/1509) ([alexlamsl](https://github.com/alexlamsl))
+
+## [v2.8.0](https://github.com/mishoo/UglifyJS2/tree/v2.8.0) (2017-02-26)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/harmony-v2.7.5...v2.8.0)
+
+**Merged pull requests:**
+
+- add harmony branch details in README [\#1507](https://github.com/mishoo/UglifyJS2/pull/1507) ([kzc](https://github.com/kzc))
+- improve error messages [\#1506](https://github.com/mishoo/UglifyJS2/pull/1506) ([alexlamsl](https://github.com/alexlamsl))
+- consolidate `evaluate` & `reduce\_vars` [\#1505](https://github.com/mishoo/UglifyJS2/pull/1505) ([alexlamsl](https://github.com/alexlamsl))
+- update docs for `pure\_funcs` & `drop\_console` [\#1503](https://github.com/mishoo/UglifyJS2/pull/1503) ([alexlamsl](https://github.com/alexlamsl))
+- allow --in-source-map inline [\#1490](https://github.com/mishoo/UglifyJS2/pull/1490) ([alexlamsl](https://github.com/alexlamsl))
+- 2.8.0 staging [\#1485](https://github.com/mishoo/UglifyJS2/pull/1485) ([alexlamsl](https://github.com/alexlamsl))
+- verify that property names after mangle are legal [\#1481](https://github.com/mishoo/UglifyJS2/pull/1481) ([anatdagan](https://github.com/anatdagan))
+- Avoid using exports when they are not defined [\#1471](https://github.com/mishoo/UglifyJS2/pull/1471) ([OndrejSpanel](https://github.com/OndrejSpanel))
+- faster tree transversal [\#1462](https://github.com/mishoo/UglifyJS2/pull/1462) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Remove duplicated code [\#1456](https://github.com/mishoo/UglifyJS2/pull/1456) ([avdg](https://github.com/avdg))
+- fix test breakage after \#1425 & \#1427 [\#1441](https://github.com/mishoo/UglifyJS2/pull/1441) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] Allow parsing regexp after arrow token [\#1439](https://github.com/mishoo/UglifyJS2/pull/1439) ([avdg](https://github.com/avdg))
+- fix mangling collision with keep\_fnames [\#1431](https://github.com/mishoo/UglifyJS2/pull/1431) ([alexlamsl](https://github.com/alexlamsl))
+- optimise binary operands with evaluate\(\) [\#1427](https://github.com/mishoo/UglifyJS2/pull/1427) ([alexlamsl](https://github.com/alexlamsl))
+- add missing LHS cases which global\_defs should avoid [\#1426](https://github.com/mishoo/UglifyJS2/pull/1426) ([alexlamsl](https://github.com/alexlamsl))
+- augment evaluate to extract within objects [\#1425](https://github.com/mishoo/UglifyJS2/pull/1425) ([alexlamsl](https://github.com/alexlamsl))
+- \[ES6\] output parens for yield when parented by AST\_Dot or AST\_Sub [\#1420](https://github.com/mishoo/UglifyJS2/pull/1420) ([kzc](https://github.com/kzc))
+- \[ES6\] Use AST\_Destructuring for lhf assignment patterns [\#1417](https://github.com/mishoo/UglifyJS2/pull/1417) ([avdg](https://github.com/avdg))
+- Have minify\(\) and tests use figure\_out\_scope\(\) as uglifyjs CLI does [\#1408](https://github.com/mishoo/UglifyJS2/pull/1408) ([kzc](https://github.com/kzc))
+- Add preventive test involving non-ascii function identifiers [\#1391](https://github.com/mishoo/UglifyJS2/pull/1391) ([avdg](https://github.com/avdg))
+- \[ES6\] Fix regression with non-ascii function identifiers [\#1390](https://github.com/mishoo/UglifyJS2/pull/1390) ([avdg](https://github.com/avdg))
+- Add note about name mangling when using --mangle-props=unquoted \(\#1314\) [\#1387](https://github.com/mishoo/UglifyJS2/pull/1387) ([wiktor-k](https://github.com/wiktor-k))
+- remove npm-shrinkwrap.json to work around npm@4.0.2 bug [\#1385](https://github.com/mishoo/UglifyJS2/pull/1385) ([kzc](https://github.com/kzc))
+
+## [harmony-v2.7.5](https://github.com/mishoo/UglifyJS2/tree/harmony-v2.7.5) (2016-11-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.7.5...harmony-v2.7.5)
+
+## [v2.7.5](https://github.com/mishoo/UglifyJS2/tree/v2.7.5) (2016-11-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.7.4...v2.7.5)
+
+**Merged pull requests:**
+
+- \[ES6\] Fix compressor not marking variables assigned by destructuring as being used [\#1355](https://github.com/mishoo/UglifyJS2/pull/1355) ([avdg](https://github.com/avdg))
+- Pass mangle options to figure\_out\_scope before mangling in tests [\#1344](https://github.com/mishoo/UglifyJS2/pull/1344) ([avdg](https://github.com/avdg))
+
+## [v2.7.4](https://github.com/mishoo/UglifyJS2/tree/v2.7.4) (2016-10-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.7.3...v2.7.4)
+
+**Merged pull requests:**
+
+- \[ES6\] Fix block scope for switch statements [\#1334](https://github.com/mishoo/UglifyJS2/pull/1334) ([avdg](https://github.com/avdg))
+- Add an option to wrap IIFEs in parenthesis [\#1310](https://github.com/mishoo/UglifyJS2/pull/1310) ([rvanvelzen](https://github.com/rvanvelzen))
+- \[ES6\] fix parsing spread arguments that are expressions [\#1309](https://github.com/mishoo/UglifyJS2/pull/1309) ([kzc](https://github.com/kzc))
+- \[ES6\] Make classes strict mode [\#1287](https://github.com/mishoo/UglifyJS2/pull/1287) ([avdg](https://github.com/avdg))
+- Make all comment options in cli available in js api [\#1285](https://github.com/mishoo/UglifyJS2/pull/1285) ([avdg](https://github.com/avdg))
+- Account for side effects in `string + expr` optimization [\#1277](https://github.com/mishoo/UglifyJS2/pull/1277) ([kzc](https://github.com/kzc))
+- implement optimization: \(x = 2 \* x\) ---\> \(x \*= 2\) [\#1270](https://github.com/mishoo/UglifyJS2/pull/1270) ([kzc](https://github.com/kzc))
+- \[ES6\] Binding pattern [\#1268](https://github.com/mishoo/UglifyJS2/pull/1268) ([avdg](https://github.com/avdg))
+
+## [v2.7.3](https://github.com/mishoo/UglifyJS2/tree/v2.7.3) (2016-08-17)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.7.2...v2.7.3)
+
+**Merged pull requests:**
+
+- Fix negate\_iife transform to return a correct tree for nested IIFEs [\#1257](https://github.com/mishoo/UglifyJS2/pull/1257) ([rvanvelzen](https://github.com/rvanvelzen))
+
+## [v2.7.2](https://github.com/mishoo/UglifyJS2/tree/v2.7.2) (2016-08-17)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.7.1...v2.7.2)
+
+**Merged pull requests:**
+
+- Fix negate\_iife regression [\#1255](https://github.com/mishoo/UglifyJS2/pull/1255) ([kzc](https://github.com/kzc))
+
+## [v2.7.1](https://github.com/mishoo/UglifyJS2/tree/v2.7.1) (2016-08-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.7.0...v2.7.1)
+
+**Merged pull requests:**
+
+- \[ES6\] Make distinction between \* method and \* operator [\#1229](https://github.com/mishoo/UglifyJS2/pull/1229) ([avdg](https://github.com/avdg))
+- Fix computed getters [\#1225](https://github.com/mishoo/UglifyJS2/pull/1225) ([avdg](https://github.com/avdg))
+- Legacy octal integer strict mode fixes [\#1224](https://github.com/mishoo/UglifyJS2/pull/1224) ([avdg](https://github.com/avdg))
+- \[ES6\] Keep empty generator as parameter value [\#1219](https://github.com/mishoo/UglifyJS2/pull/1219) ([avdg](https://github.com/avdg))
+
+## [v2.7.0](https://github.com/mishoo/UglifyJS2/tree/v2.7.0) (2016-07-03)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.6.4...v2.7.0)
+
+**Merged pull requests:**
+
+- \[ES6\] Throw error if new.target is like new.foo [\#1170](https://github.com/mishoo/UglifyJS2/pull/1170) ([avdg](https://github.com/avdg))
+- \[ES6\] Various fixes for template strings [\#1160](https://github.com/mishoo/UglifyJS2/pull/1160) ([avdg](https://github.com/avdg))
+
+## [v2.6.4](https://github.com/mishoo/UglifyJS2/tree/v2.6.4) (2016-06-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.6.3...v2.6.4)
+
+**Merged pull requests:**
+
+- Fix conditional expressions of form \(x ? -1 : -1\) [\#1155](https://github.com/mishoo/UglifyJS2/pull/1155) ([kzc](https://github.com/kzc))
+- Test --self build [\#1152](https://github.com/mishoo/UglifyJS2/pull/1152) ([rvanvelzen](https://github.com/rvanvelzen))
+- Fixes to prevent failing tests after merging master [\#1150](https://github.com/mishoo/UglifyJS2/pull/1150) ([avdg](https://github.com/avdg))
+
+## [v2.6.3](https://github.com/mishoo/UglifyJS2/tree/v2.6.3) (2016-06-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.6.2...v2.6.3)
+
+**Merged pull requests:**
+
+- Don't convert all strings to directives from moz-ast [\#1183](https://github.com/mishoo/UglifyJS2/pull/1183) ([avdg](https://github.com/avdg))
+- Fix test262 failures related to \<, \<=, in and instanceof [\#1134](https://github.com/mishoo/UglifyJS2/pull/1134) ([avdg](https://github.com/avdg))
+- Various LineTerminator  changes [\#1131](https://github.com/mishoo/UglifyJS2/pull/1131) ([avdg](https://github.com/avdg))
+- Don't allow with statements in strict mode [\#1129](https://github.com/mishoo/UglifyJS2/pull/1129) ([avdg](https://github.com/avdg))
+- \[ES6\] Fix yield star newline [\#1126](https://github.com/mishoo/UglifyJS2/pull/1126) ([avdg](https://github.com/avdg))
+- Export tokenizer function [\#1113](https://github.com/mishoo/UglifyJS2/pull/1113) ([ChALkeR](https://github.com/ChALkeR))
+- \[ES6\] Fix generators [\#1104](https://github.com/mishoo/UglifyJS2/pull/1104) ([avdg](https://github.com/avdg))
+- collapse\_vars: Do not consider RegExp literals to be constants [\#1102](https://github.com/mishoo/UglifyJS2/pull/1102) ([kzc](https://github.com/kzc))
+- Only allow `var` definitions to be moved into the for-init clause [\#1081](https://github.com/mishoo/UglifyJS2/pull/1081) ([rvanvelzen](https://github.com/rvanvelzen))
+- Do not apply negate\_iife optimization to `new` expression [\#1074](https://github.com/mishoo/UglifyJS2/pull/1074) ([kzc](https://github.com/kzc))
+- Avoid syntax error in yield assignments [\#1059](https://github.com/mishoo/UglifyJS2/pull/1059) ([not-an-aardvark](https://github.com/not-an-aardvark))
+- Hoist functions when reversing if \(x\) return; ... vs. if \(!x\) ... [\#1053](https://github.com/mishoo/UglifyJS2/pull/1053) ([rvanvelzen](https://github.com/rvanvelzen))
+- Merge master into harmony [\#1047](https://github.com/mishoo/UglifyJS2/pull/1047) ([rvanvelzen](https://github.com/rvanvelzen))
+- Parse comments without recursion to avoid RangeError. [\#1045](https://github.com/mishoo/UglifyJS2/pull/1045) ([kzc](https://github.com/kzc))
+- Simplify member\(name, array\) implementation. [\#1032](https://github.com/mishoo/UglifyJS2/pull/1032) ([kzc](https://github.com/kzc))
+- Speedup `unused` compress option for already minified code [\#1024](https://github.com/mishoo/UglifyJS2/pull/1024) ([kzc](https://github.com/kzc))
+- fix \#1021 [\#1023](https://github.com/mishoo/UglifyJS2/pull/1023) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Escape all ASCII control characters within strings for ascii\_only [\#1019](https://github.com/mishoo/UglifyJS2/pull/1019) ([kzc](https://github.com/kzc))
+- Do not produce `let` as a variable name in mangle. [\#1011](https://github.com/mishoo/UglifyJS2/pull/1011) ([kzc](https://github.com/kzc))
+- Ignore mangle sort option [\#991](https://github.com/mishoo/UglifyJS2/pull/991) ([kzc](https://github.com/kzc))
+
+## [v2.6.2](https://github.com/mishoo/UglifyJS2/tree/v2.6.2) (2016-02-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.6.1...v2.6.2)
+
+**Merged pull requests:**
+
+- Take operator || precendence into account for AST\_If optimization. [\#981](https://github.com/mishoo/UglifyJS2/pull/981) ([kzc](https://github.com/kzc))
+- Fix \#931: Create arrow functions in maybe\_assign so that they can be … [\#967](https://github.com/mishoo/UglifyJS2/pull/967) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Fixes \#951 missing export for SymbolDef [\#952](https://github.com/mishoo/UglifyJS2/pull/952) ([Bobris](https://github.com/Bobris))
+- collapse\_vars: fix if/else and ternary operator side effects [\#949](https://github.com/mishoo/UglifyJS2/pull/949) ([kzc](https://github.com/kzc))
+- collapse\_vars: document the compress option in README [\#948](https://github.com/mishoo/UglifyJS2/pull/948) ([kzc](https://github.com/kzc))
+- Add mangleProperties documentation to README [\#943](https://github.com/mishoo/UglifyJS2/pull/943) ([bryanerayner](https://github.com/bryanerayner))
+- fix bug in collapse\_vars for right side of "||" and "&&" [\#942](https://github.com/mishoo/UglifyJS2/pull/942) ([kzc](https://github.com/kzc))
+- Mark vars with /\*\* @const \*/ pragma as consts so they can be eliminated. [\#928](https://github.com/mishoo/UglifyJS2/pull/928) ([STRML](https://github.com/STRML))
+- Never mangle arguments and keep them in their scope [\#918](https://github.com/mishoo/UglifyJS2/pull/918) ([avdg](https://github.com/avdg))
+- Unit tests [\#905](https://github.com/mishoo/UglifyJS2/pull/905) ([avdg](https://github.com/avdg))
+- Do not allow newlines in string literals [\#903](https://github.com/mishoo/UglifyJS2/pull/903) ([avdg](https://github.com/avdg))
+- Semicolon after do...while statement is optional [\#896](https://github.com/mishoo/UglifyJS2/pull/896) ([avdg](https://github.com/avdg))
+- Update README URLs based on HTTP redirects [\#879](https://github.com/mishoo/UglifyJS2/pull/879) ([ReadmeCritic](https://github.com/ReadmeCritic))
+- \#873 Fix `conditionals` optimizations with default compress options [\#874](https://github.com/mishoo/UglifyJS2/pull/874) ([kzc](https://github.com/kzc))
+- Feature/harmony defaults [\#872](https://github.com/mishoo/UglifyJS2/pull/872) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Harmony: classes [\#870](https://github.com/mishoo/UglifyJS2/pull/870) ([fabiosantoscode](https://github.com/fabiosantoscode))
+
+## [v2.6.1](https://github.com/mishoo/UglifyJS2/tree/v2.6.1) (2015-11-16)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.6.0...v2.6.1)
+
+**Merged pull requests:**
+
+- Fix docs for keep\_fargs [\#864](https://github.com/mishoo/UglifyJS2/pull/864) ([plievone](https://github.com/plievone))
+
+## [v2.6.0](https://github.com/mishoo/UglifyJS2/tree/v2.6.0) (2015-11-12)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.5.0...v2.6.0)
+
+**Merged pull requests:**
+
+- Have mozilla AST RegExpLiteral parser use regex.pattern and regex.flags [\#854](https://github.com/mishoo/UglifyJS2/pull/854) ([kzc](https://github.com/kzc))
+- Fix RegExp literal in mozilla AST, add --dump-spidermonkey-ast flag [\#853](https://github.com/mishoo/UglifyJS2/pull/853) ([kzc](https://github.com/kzc))
+- fixes \#845: \v escaping should be restricted to "screw\_ie8" mode [\#847](https://github.com/mishoo/UglifyJS2/pull/847) ([michaelficarra](https://github.com/michaelficarra))
+- Harmony: allow use of `of` as a name. [\#844](https://github.com/mishoo/UglifyJS2/pull/844) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Fix \#836 [\#837](https://github.com/mishoo/UglifyJS2/pull/837) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Escape \v like other special characters  [\#833](https://github.com/mishoo/UglifyJS2/pull/833) ([startswithaj](https://github.com/startswithaj))
+- add support for --pure-funcs option [\#831](https://github.com/mishoo/UglifyJS2/pull/831) ([pirxpilot](https://github.com/pirxpilot))
+- Fix other operator output producing \<!-- or --\> [\#829](https://github.com/mishoo/UglifyJS2/pull/829) ([kzc](https://github.com/kzc))
+- Feature/harmony computed props [\#806](https://github.com/mishoo/UglifyJS2/pull/806) ([fabiosantoscode](https://github.com/fabiosantoscode))
+
+## [v2.5.0](https://github.com/mishoo/UglifyJS2/tree/v2.5.0) (2015-10-11)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.24...v2.5.0)
+
+**Merged pull requests:**
+
+- Fix handling of "use asm" when no flags are passed [\#822](https://github.com/mishoo/UglifyJS2/pull/822) ([kzc](https://github.com/kzc))
+- Add node 4.x in Travis [\#808](https://github.com/mishoo/UglifyJS2/pull/808) ([avdg](https://github.com/avdg))
+- sFix crash, remove unused code and state variable. [\#795](https://github.com/mishoo/UglifyJS2/pull/795) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Harmony: template strings [\#794](https://github.com/mishoo/UglifyJS2/pull/794) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- allow for anonymous map generation using string type check [\#786](https://github.com/mishoo/UglifyJS2/pull/786) ([istr](https://github.com/istr))
+- Parse ES6 number literals, round 2 [\#775](https://github.com/mishoo/UglifyJS2/pull/775) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- remove Symbol's argument when we're unsafe and Symbol is undeclared [\#774](https://github.com/mishoo/UglifyJS2/pull/774) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Fix evaluating the typeof an arrow function. [\#773](https://github.com/mishoo/UglifyJS2/pull/773) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Parse binary number literals [\#771](https://github.com/mishoo/UglifyJS2/pull/771) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Feature/harmony destructuring expression [\#768](https://github.com/mishoo/UglifyJS2/pull/768) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- \[Fix\] --define replaces SymbolRefs in LHS of assignments [\#767](https://github.com/mishoo/UglifyJS2/pull/767) ([vjeux](https://github.com/vjeux))
+- Feature/harmony super [\#763](https://github.com/mishoo/UglifyJS2/pull/763) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Feature/harmony arrows [\#760](https://github.com/mishoo/UglifyJS2/pull/760) ([fabiosantoscode](https://github.com/fabiosantoscode))
+- Fix semicolon printing when restricting max line length [\#757](https://github.com/mishoo/UglifyJS2/pull/757) ([rvanvelzen](https://github.com/rvanvelzen))
+- Fix semicolon printing when restricting max line length [\#756](https://github.com/mishoo/UglifyJS2/pull/756) ([rvanvelzen](https://github.com/rvanvelzen))
+- Support wrap and exportAll options for node.js tools. [\#753](https://github.com/mishoo/UglifyJS2/pull/753) ([Surgo](https://github.com/Surgo))
+- fromString option, use index from argument array for filename instead of "?" [\#736](https://github.com/mishoo/UglifyJS2/pull/736) ([AlbertoGP](https://github.com/AlbertoGP))
+- Add keep\_fnames compressor option to README.md [\#729](https://github.com/mishoo/UglifyJS2/pull/729) ([DrewML](https://github.com/DrewML))
+
+## [v2.4.24](https://github.com/mishoo/UglifyJS2/tree/v2.4.24) (2015-07-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.23...v2.4.24)
+
+**Merged pull requests:**
+
+- optimizations for && and || where left side is constant expression [\#735](https://github.com/mishoo/UglifyJS2/pull/735) ([kzc](https://github.com/kzc))
+- Add --mangle-regex option [\#733](https://github.com/mishoo/UglifyJS2/pull/733) ([jcxplorer](https://github.com/jcxplorer))
+
+## [v2.4.23](https://github.com/mishoo/UglifyJS2/tree/v2.4.23) (2015-05-20)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.22...v2.4.23)
+
+## [v2.4.22](https://github.com/mishoo/UglifyJS2/tree/v2.4.22) (2015-05-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.21...v2.4.22)
+
+## [v2.4.21](https://github.com/mishoo/UglifyJS2/tree/v2.4.21) (2015-05-04)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.20...v2.4.21)
+
+## [v2.4.20](https://github.com/mishoo/UglifyJS2/tree/v2.4.20) (2015-04-13)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.19...v2.4.20)
+
+**Merged pull requests:**
+
+- Document passing source maps directly to minify\(\) using inSourceMap [\#669](https://github.com/mishoo/UglifyJS2/pull/669) ([caldwell](https://github.com/caldwell))
+
+## [v2.4.19](https://github.com/mishoo/UglifyJS2/tree/v2.4.19) (2015-03-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.18...v2.4.19)
+
+**Merged pull requests:**
+
+- Fix long options [\#660](https://github.com/mishoo/UglifyJS2/pull/660) ([ntkme](https://github.com/ntkme))
+
+## [v2.4.18](https://github.com/mishoo/UglifyJS2/tree/v2.4.18) (2015-03-29)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.17...v2.4.18)
+
+## [v2.4.17](https://github.com/mishoo/UglifyJS2/tree/v2.4.17) (2015-03-10)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.16...v2.4.17)
+
+**Merged pull requests:**
+
+- Allow uglify to handle executable files [\#810](https://github.com/mishoo/UglifyJS2/pull/810) ([avdg](https://github.com/avdg))
+- Drop all `console` statements properly [\#629](https://github.com/mishoo/UglifyJS2/pull/629) ([rvanvelzen](https://github.com/rvanvelzen))
+- fixes issue \#621 SourceMap toString JSON format [\#622](https://github.com/mishoo/UglifyJS2/pull/622) ([brycecr](https://github.com/brycecr))
+- Give parser more unicode support [\#615](https://github.com/mishoo/UglifyJS2/pull/615) ([avdg](https://github.com/avdg))
+- Replace the correct node when replacing in `void` sequences [\#612](https://github.com/mishoo/UglifyJS2/pull/612) ([rvanvelzen](https://github.com/rvanvelzen))
+- Document `--` for usage in CLI class [\#606](https://github.com/mishoo/UglifyJS2/pull/606) ([rvanvelzen](https://github.com/rvanvelzen))
+- Add an option to prevent function names from being mangled [\#603](https://github.com/mishoo/UglifyJS2/pull/603) ([rvanvelzen](https://github.com/rvanvelzen))
+- Use yargs instead of optimist. [\#600](https://github.com/mishoo/UglifyJS2/pull/600) ([knpwrs](https://github.com/knpwrs))
+- Fix \#597 [\#599](https://github.com/mishoo/UglifyJS2/pull/599) ([rvanvelzen](https://github.com/rvanvelzen))
+- Fix max\_line\_len not working for JSON files [\#592](https://github.com/mishoo/UglifyJS2/pull/592) ([micschro](https://github.com/micschro))
+- fix base54 [\#584](https://github.com/mishoo/UglifyJS2/pull/584) ([clyfish](https://github.com/clyfish))
+- Fix \#569 [\#570](https://github.com/mishoo/UglifyJS2/pull/570) ([rvanvelzen](https://github.com/rvanvelzen))
+- added @ngInject support for inline functions [\#482](https://github.com/mishoo/UglifyJS2/pull/482) ([arty-name](https://github.com/arty-name))
+
+## [v2.4.16](https://github.com/mishoo/UglifyJS2/tree/v2.4.16) (2014-12-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.15...v2.4.16)
+
+**Merged pull requests:**
+
+- Don't warn for an unreferenced exception symbol in a catch block. [\#549](https://github.com/mishoo/UglifyJS2/pull/549) ([Arnavion](https://github.com/Arnavion))
+- Use uglify source map token names if missing [\#546](https://github.com/mishoo/UglifyJS2/pull/546) ([jacobk](https://github.com/jacobk))
+- Conditional assignment of equivalent constants compressed  \( x=y?1:1 --\> x=1 \) [\#541](https://github.com/mishoo/UglifyJS2/pull/541) ([TalAter](https://github.com/TalAter))
+- Added example for usage with SpiderMonkey AST [\#529](https://github.com/mishoo/UglifyJS2/pull/529) ([RReverser](https://github.com/RReverser))
+- Added generative testing for AST conversions. [\#527](https://github.com/mishoo/UglifyJS2/pull/527) ([RReverser](https://github.com/RReverser))
+- SpiderMonkey AST conversion [\#526](https://github.com/mishoo/UglifyJS2/pull/526) ([RReverser](https://github.com/RReverser))
+- Added license [\#522](https://github.com/mishoo/UglifyJS2/pull/522) ([gdw2](https://github.com/gdw2))
+
+## [v2.4.15](https://github.com/mishoo/UglifyJS2/tree/v2.4.15) (2014-07-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.14...v2.4.15)
+
+**Merged pull requests:**
+
+- Update .travis.yml to pass the test on Travis CI [\#499](https://github.com/mishoo/UglifyJS2/pull/499) ([shinnn](https://github.com/shinnn))
+
+## [v2.4.14](https://github.com/mishoo/UglifyJS2/tree/v2.4.14) (2014-06-12)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.13...v2.4.14)
+
+**Merged pull requests:**
+
+- Fix sourceMapIncludeSources exception in Node API [\#470](https://github.com/mishoo/UglifyJS2/pull/470) ([ebednarz](https://github.com/ebednarz))
+- Allow colons in the pairs passed to AST\_Toplevel.wrap\_enclose [\#454](https://github.com/mishoo/UglifyJS2/pull/454) ([Arnavion](https://github.com/Arnavion))
+- Handle TryStatements trees from acorn \>=0.2.0 [\#445](https://github.com/mishoo/UglifyJS2/pull/445) ([ConradIrwin](https://github.com/ConradIrwin))
+
+## [v2.4.13](https://github.com/mishoo/UglifyJS2/tree/v2.4.13) (2014-03-11)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.12...v2.4.13)
+
+**Merged pull requests:**
+
+- Handle the case when SourceMapConsumer.originalPositionFor returns null source. [\#439](https://github.com/mishoo/UglifyJS2/pull/439) ([Arnavion](https://github.com/Arnavion))
+- Simplify nested conditionals if possible [\#424](https://github.com/mishoo/UglifyJS2/pull/424) ([mattbasta](https://github.com/mattbasta))
+- Fix readme typo \(when -\> with\) [\#422](https://github.com/mishoo/UglifyJS2/pull/422) ([mourner](https://github.com/mourner))
+
+## [v2.4.12](https://github.com/mishoo/UglifyJS2/tree/v2.4.12) (2014-01-26)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.11...v2.4.12)
+
+**Merged pull requests:**
+
+- Don't unescape \x00 in regexes \(it breaks IE8\) [\#408](https://github.com/mishoo/UglifyJS2/pull/408) ([danielstutzman](https://github.com/danielstutzman))
+
+## [v2.4.11](https://github.com/mishoo/UglifyJS2/tree/v2.4.11) (2014-01-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.10...v2.4.11)
+
+**Merged pull requests:**
+
+- Don't unescape byte order marks in regexps [\#402](https://github.com/mishoo/UglifyJS2/pull/402) ([lautis](https://github.com/lautis))
+
+## [v2.4.10](https://github.com/mishoo/UglifyJS2/tree/v2.4.10) (2014-01-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.9...v2.4.10)
+
+## [v2.4.9](https://github.com/mishoo/UglifyJS2/tree/v2.4.9) (2014-01-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.8...v2.4.9)
+
+**Merged pull requests:**
+
+- Add support for sourcesContent property in source maps [\#398](https://github.com/mishoo/UglifyJS2/pull/398) ([arty-name](https://github.com/arty-name))
+
+## [v2.4.8](https://github.com/mishoo/UglifyJS2/tree/v2.4.8) (2013-12-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.7...v2.4.8)
+
+**Merged pull requests:**
+
+- bugfix \#242 [\#371](https://github.com/mishoo/UglifyJS2/pull/371) ([colorhook](https://github.com/colorhook))
+- Make `DefaultsError` a real `Error` object [\#245](https://github.com/mishoo/UglifyJS2/pull/245) ([ForbesLindesay](https://github.com/ForbesLindesay))
+
+## [v2.4.7](https://github.com/mishoo/UglifyJS2/tree/v2.4.7) (2013-12-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.6...v2.4.7)
+
+## [v2.4.6](https://github.com/mishoo/UglifyJS2/tree/v2.4.6) (2013-11-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.5...v2.4.6)
+
+## [v2.4.5](https://github.com/mishoo/UglifyJS2/tree/v2.4.5) (2013-11-28)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.4...v2.4.5)
+
+## [v2.4.4](https://github.com/mishoo/UglifyJS2/tree/v2.4.4) (2013-11-27)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.3...v2.4.4)
+
+## [v2.4.3](https://github.com/mishoo/UglifyJS2/tree/v2.4.3) (2013-11-06)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.2...v2.4.3)
+
+## [v2.4.2](https://github.com/mishoo/UglifyJS2/tree/v2.4.2) (2013-11-03)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.1...v2.4.2)
+
+**Merged pull requests:**
+
+- Disallow reversal where lhs has higher or equal precedence [\#336](https://github.com/mishoo/UglifyJS2/pull/336) ([rvanvelzen](https://github.com/rvanvelzen))
+- Fix RHS concat \(raised in \#330\) [\#331](https://github.com/mishoo/UglifyJS2/pull/331) ([rvanvelzen](https://github.com/rvanvelzen))
+- Unit test to detect issue in 8d14efe for \#126 that causes aggressive parenthesis removal, functional differences [\#330](https://github.com/mishoo/UglifyJS2/pull/330) ([markjaquith](https://github.com/markjaquith))
+- Fix \#269 [\#325](https://github.com/mishoo/UglifyJS2/pull/325) ([rvanvelzen](https://github.com/rvanvelzen))
+- Fix \#280 [\#323](https://github.com/mishoo/UglifyJS2/pull/323) ([rvanvelzen](https://github.com/rvanvelzen))
+- Add an exit code to the test suite [\#322](https://github.com/mishoo/UglifyJS2/pull/322) ([rvanvelzen](https://github.com/rvanvelzen))
+
+## [v2.4.1](https://github.com/mishoo/UglifyJS2/tree/v2.4.1) (2013-10-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.4.0...v2.4.1)
+
+**Merged pull requests:**
+
+- Only allow identifier start characters at the beginning of identifiers. [\#308](https://github.com/mishoo/UglifyJS2/pull/308) ([glasser](https://github.com/glasser))
+
+## [v2.4.0](https://github.com/mishoo/UglifyJS2/tree/v2.4.0) (2013-08-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.6...v2.4.0)
+
+**Merged pull requests:**
+
+- fixes \#259: don't unnecessarily quote object properties when --screw-ie8 [\#270](https://github.com/mishoo/UglifyJS2/pull/270) ([michaelficarra](https://github.com/michaelficarra))
+- Escape null characters as \x00 [\#220](https://github.com/mishoo/UglifyJS2/pull/220) ([lautis](https://github.com/lautis))
+
+## [v2.3.6](https://github.com/mishoo/UglifyJS2/tree/v2.3.6) (2013-05-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.5...v2.3.6)
+
+**Merged pull requests:**
+
+- SourceMapping pragma has changed to //\# [\#213](https://github.com/mishoo/UglifyJS2/pull/213) ([mattrobenolt](https://github.com/mattrobenolt))
+
+## [v2.3.5](https://github.com/mishoo/UglifyJS2/tree/v2.3.5) (2013-05-19)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.4...v2.3.5)
+
+## [v2.3.4](https://github.com/mishoo/UglifyJS2/tree/v2.3.4) (2013-05-15)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.3...v2.3.4)
+
+## [v2.3.3](https://github.com/mishoo/UglifyJS2/tree/v2.3.3) (2013-05-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.2...v2.3.3)
+
+**Merged pull requests:**
+
+- Add CI build for supported Node versions [\#202](https://github.com/mishoo/UglifyJS2/pull/202) ([nschonni](https://github.com/nschonni))
+
+## [v2.3.2](https://github.com/mishoo/UglifyJS2/tree/v2.3.2) (2013-05-09)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.1...v2.3.2)
+
+## [v2.3.1](https://github.com/mishoo/UglifyJS2/tree/v2.3.1) (2013-05-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3.0...v2.3.1)
+
+**Merged pull requests:**
+
+- Fix typo in bin and readme [\#195](https://github.com/mishoo/UglifyJS2/pull/195) ([kimjoar](https://github.com/kimjoar))
+- Add README syntax highlighting [\#194](https://github.com/mishoo/UglifyJS2/pull/194) ([ulikoehler](https://github.com/ulikoehler))
+
+## [v2.3.0](https://github.com/mishoo/UglifyJS2/tree/v2.3.0) (2013-05-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.3...v2.3.0)
+
+## [v2.3](https://github.com/mishoo/UglifyJS2/tree/v2.3) (2013-05-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.2.5...v2.3)
+
+**Merged pull requests:**
+
+- use dotted member access when --screw-ie8 option given [\#191](https://github.com/mishoo/UglifyJS2/pull/191) ([michaelficarra](https://github.com/michaelficarra))
+- unbalanced parentheses in readme [\#190](https://github.com/mishoo/UglifyJS2/pull/190) ([michaelficarra](https://github.com/michaelficarra))
+- Fix typeof evaluation for regex and function [\#181](https://github.com/mishoo/UglifyJS2/pull/181) ([candid82](https://github.com/candid82))
+- renamed --screw-ie to --screw-oldie, documented it in README.md, indicat... [\#163](https://github.com/mishoo/UglifyJS2/pull/163) ([mgol](https://github.com/mgol))
+- Read the entire STDIN. [\#146](https://github.com/mishoo/UglifyJS2/pull/146) ([mbostock](https://github.com/mbostock))
+- Allow inSourceMap option to be a generated JSON source map [\#125](https://github.com/mishoo/UglifyJS2/pull/125) ([devongovett](https://github.com/devongovett))
+
+## [v2.2.5](https://github.com/mishoo/UglifyJS2/tree/v2.2.5) (2013-02-14)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.2.4...v2.2.5)
+
+**Merged pull requests:**
+
+- Wraps sourceMappingURL in a multiline comment. Fixes \#108 [\#111](https://github.com/mishoo/UglifyJS2/pull/111) ([mattrobenolt](https://github.com/mattrobenolt))
+
+## [v2.2.4](https://github.com/mishoo/UglifyJS2/tree/v2.2.4) (2013-02-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.2.3...v2.2.4)
+
+**Merged pull requests:**
+
+- Fix \#105: property comparison to undefined is not always safe [\#106](https://github.com/mishoo/UglifyJS2/pull/106) ([gibson042](https://github.com/gibson042))
+- Update installation instructions [\#98](https://github.com/mishoo/UglifyJS2/pull/98) ([ForbesLindesay](https://github.com/ForbesLindesay))
+- Add better fromstring docs. [\#94](https://github.com/mishoo/UglifyJS2/pull/94) ([paulmillr](https://github.com/paulmillr))
+- Compressor options use underscores rather than hyphens [\#90](https://github.com/mishoo/UglifyJS2/pull/90) ([jakearchibald](https://github.com/jakearchibald))
+
+## [v2.2.3](https://github.com/mishoo/UglifyJS2/tree/v2.2.3) (2013-01-04)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.2.2...v2.2.3)
+
+**Merged pull requests:**
+
+- Add a --version option [\#87](https://github.com/mishoo/UglifyJS2/pull/87) ([BenoitZugmeyer](https://github.com/BenoitZugmeyer))
+
+## [v2.2.2](https://github.com/mishoo/UglifyJS2/tree/v2.2.2) (2012-12-06)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.2.1...v2.2.2)
+
+**Merged pull requests:**
+
+- Fixed reading from STDIN [\#58](https://github.com/mishoo/UglifyJS2/pull/58) ([roxeteer](https://github.com/roxeteer))
+
+## [v2.2.1](https://github.com/mishoo/UglifyJS2/tree/v2.2.1) (2012-11-23)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.2.0...v2.2.1)
+
+## [v2.2.0](https://github.com/mishoo/UglifyJS2/tree/v2.2.0) (2012-11-21)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.11...v2.2.0)
+
+**Merged pull requests:**
+
+- Add simple optimization for empty-string concats. [\#45](https://github.com/mishoo/UglifyJS2/pull/45) ([rvanvelzen](https://github.com/rvanvelzen))
+
+## [v2.1.11](https://github.com/mishoo/UglifyJS2/tree/v2.1.11) (2012-11-12)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.10...v2.1.11)
+
+**Merged pull requests:**
+
+- Convert x.toString\(\) to ""+x instead of x+"" [\#41](https://github.com/mishoo/UglifyJS2/pull/41) ([Skalman](https://github.com/Skalman))
+
+## [v2.1.10](https://github.com/mishoo/UglifyJS2/tree/v2.1.10) (2012-11-08)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.9...v2.1.10)
+
+## [v2.1.9](https://github.com/mishoo/UglifyJS2/tree/v2.1.9) (2012-11-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.8...v2.1.9)
+
+## [v2.1.8](https://github.com/mishoo/UglifyJS2/tree/v2.1.8) (2012-11-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.7...v2.1.8)
+
+## [v2.1.7](https://github.com/mishoo/UglifyJS2/tree/v2.1.7) (2012-11-07)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.6...v2.1.7)
+
+## [v2.1.6](https://github.com/mishoo/UglifyJS2/tree/v2.1.6) (2012-11-01)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.5...v2.1.6)
+
+## [v2.1.5](https://github.com/mishoo/UglifyJS2/tree/v2.1.5) (2012-10-30)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.4...v2.1.5)
+
+## [v2.1.4](https://github.com/mishoo/UglifyJS2/tree/v2.1.4) (2012-10-25)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.3...v2.1.4)
+
+## [v2.1.3](https://github.com/mishoo/UglifyJS2/tree/v2.1.3) (2012-10-24)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.2...v2.1.3)
+
+## [v2.1.2](https://github.com/mishoo/UglifyJS2/tree/v2.1.2) (2012-10-22)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1.1...v2.1.2)
+
+**Merged pull requests:**
+
+- Allow to specify sourceRoot in minify [\#19](https://github.com/mishoo/UglifyJS2/pull/19) ([SevInf](https://github.com/SevInf))
+
+## [v2.1.1](https://github.com/mishoo/UglifyJS2/tree/v2.1.1) (2012-10-18)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.1...v2.1.1)
+
+## [v2.1](https://github.com/mishoo/UglifyJS2/tree/v2.1) (2012-10-17)
+[Full Changelog](https://github.com/mishoo/UglifyJS2/compare/v2.0...v2.1)
+
+**Merged pull requests:**
+
+- Fix crash in minify function [\#8](https://github.com/mishoo/UglifyJS2/pull/8) ([SevInf](https://github.com/SevInf))
+
+## [v2.0](https://github.com/mishoo/UglifyJS2/tree/v2.0) (2012-10-05)
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
Thank you for great work! This project saves a lot of bandwidth in the world over!

There are some requests for changelog (#934, #2130, #2744, #2745, #2950).
This pr's CHANGELOG.md is created by [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator).
It can create just one command, very easy :)

Add: You can review at https://github.com/sapics/UglifyJS2/blob/changelog/CHANGELOG.md