### PR TITLE
Show help if none of the options are supplied 

### DIFF
--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -54,6 +54,9 @@ program.option("--verbose", "Print diagnostic messages.");
 program.option("--warn", "Print warning messages.");
 program.option("--wrap <name>", "Embed everything as a function with “exports” corresponding to “name” globally.");
 program.arguments("[files...]").parseArgv(process.argv);
+if (!program.args.length){
+   program.outputHelp();
+}
 if (program.configFile) {
     options = JSON.parse(read_file(program.configFile));
 }
@@ -168,9 +171,6 @@ if (program.self) {
         run();
     });
     process.stdin.resume();
-}
-if (!program.args.length){
-   program.help();
 }
 
 function convert_ast(fn) {

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+﻿#! /usr/bin/env node
 // -*- js -*-
 
 "use strict";
@@ -168,6 +168,9 @@ if (program.self) {
         run();
     });
     process.stdin.resume();
+}
+if (!program.args.length){
+   program.help();
 }
 
 function convert_ast(fn) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "uglify-js",
+  "version": "3.4.9",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    }
+  }
+}


### PR DESCRIPTION
As per the change help shows up if the user fires in `uglifyjs` without any further arguments.
For instance, the user may fire in `uglifyjs` just to ensure that the installation went right.
🤔 