### PR TITLE
fix corner cases in `unused` & `varify`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -7284,7 +7284,7 @@ merge(Compressor.prototype, {
     });
 
     function is_safe_lexical(def) {
-        return def.orig.length < (def.orig[0] instanceof AST_SymbolLambda ? 3 : 2);
+        return def.name != "arguments" && def.orig.length < (def.orig[0] instanceof AST_SymbolLambda ? 3 : 2);
     }
 
     function may_overlap(compressor, def) {

--- a/test/compress/const.js
+++ b/test/compress/const.js
@@ -1347,3 +1347,31 @@ issue_4305_2: {
     }
     expect_stdout: true
 }
+
+issue_4365_1: {
+    options = {
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        const arguments = 42;
+    }
+    expect: {
+        const arguments = 42;
+    }
+    expect_stdout: true
+}
+
+issue_4365_2: {
+    options = {
+        toplevel: true,
+        varify: true,
+    }
+    input: {
+        const arguments = 42;
+    }
+    expect: {
+        const arguments = 42;
+    }
+    expect_stdout: true
+}


### PR DESCRIPTION
fixes #4365