### PR TITLE
Fix overwriting existing sourcesContent in sourcemaps

### DIFF
--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -144,7 +144,9 @@ function SourceMap(options) {
             add(source, gen_line, gen_col, orig_line, orig_col, name);
         } : add,
         setSourceContent: sources_content ? function(source, content) {
-            sources_content[source] = content;
+            if (!sources_content[source]) {
+                sources_content[source] = content;
+            }
         } : noop,
         toString: function() {
             return JSON.stringify({

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -144,7 +144,7 @@ function SourceMap(options) {
             add(source, gen_line, gen_col, orig_line, orig_col, name);
         } : add,
         setSourceContent: sources_content ? function(source, content) {
-            if (!sources_content[source]) {
+            if (!HOP(sources_content, source)) {
                 sources_content[source] = content;
             }
         } : noop,

--- a/lib/sourcemap.js
+++ b/lib/sourcemap.js
@@ -144,7 +144,7 @@ function SourceMap(options) {
             add(source, gen_line, gen_col, orig_line, orig_col, name);
         } : add,
         setSourceContent: sources_content ? function(source, content) {
-            if (!HOP(sources_content, source)) {
+            if (!(source in sources_content)) {
                 sources_content[source] = content;
             }
         } : noop,

--- a/test/mocha/sourcemaps.js
+++ b/test/mocha/sourcemaps.js
@@ -244,6 +244,39 @@ describe("sourcemaps", function() {
             assert.strictEqual(result.code, '(function(){console.log("hello")}).call(this);');
             assert.strictEqual(result.map, '{"version":3,"sources":["main.coffee"],"names":["console","log"],"mappings":"CAAA,WAAAA,QAAQC,IAAI"}');
         });
+        it("Should not overwrite existing sourcesContent", function() {
+            var result = UglifyJS.minify({
+                "in.js": [
+                    '"use strict";',
+                    "",
+                    "var _window$foo = window.foo,",
+                    "    a = _window$foo[0],",
+                    "    b = _window$foo[1];",
+                ].join("\n"),
+            }, {
+                compress: false,
+                mangle: false,
+                sourceMap: {
+                    content: {
+                        version: 3,
+                        sources: [ "in.js" ],
+                        names: [
+                            "window",
+                            "foo",
+                            "a",
+                            "b",
+                        ],
+                        mappings: ";;kBAAaA,MAAM,CAACC,G;IAAfC,C;IAAGC,C",
+                        file: "in.js",
+                        sourcesContent: [ "let [a, b] = window.foo;\n" ],
+                    },
+                    includeSources: true,
+                },
+            });
+            if (result.error) throw result.error;
+            assert.strictEqual(result.code, '"use strict";var _window$foo=window.foo,a=_window$foo[0],b=_window$foo[1];');
+            assert.strictEqual(result.map, '{"version":3,"sources":["in.js"],"sourcesContent":["let [a, b] = window.foo;\\n"],"names":["window","foo","a","b"],"mappings":"6BAAaA,OAAOC,IAAfC,E,eAAGC,E"}');
+        });
     });
 
     describe("sourceMapInline", function() {


### PR DESCRIPTION
When running Uglify on already processed code, when given a sourcemap that includes a `sourcesContent` with the original code, it's generating a sourcemap which instead references the intermediate source content.

As an example, running uglify on [this file from Babel](https://gist.github.com/Jimbly/64c08aa316b7e4ebdddfeda2380dd296) generates [this bad output](http://sokra.github.io/source-map-visualization/#base64,InVzZSBzdHJpY3QiO3ZhciBfd2luZG93JGZvbz13aW5kb3cuZm9vLGE9X3dpbmRvdyRmb29bMF0sYj1fd2luZG93JGZvb1sxXTsKLyogYmFzZTY0IHNvdXJjZSBtYXAgcmVtb3ZlZCAqLw==,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluLmpzIl0sInNvdXJjZXNDb250ZW50IjpbIlwidXNlIHN0cmljdFwiO1xuXG52YXIgX3dpbmRvdyRmb28gPSB3aW5kb3cuZm9vLFxuICAgIGEgPSBfd2luZG93JGZvb1swXSxcbiAgICBiID0gX3dpbmRvdyRmb29bMV07XG4vLyMgc291cmNlTWFwcGluZ1VSTD1kYXRhOmFwcGxpY2F0aW9uL2pzb247Y2hhcnNldD11dGY4O2Jhc2U2NCxleUoyWlhKemFXOXVJam96TENKemIzVnlZMlZ6SWpwYkltbHVMbXB6SWwwc0ltNWhiV1Z6SWpwYkluZHBibVJ2ZHlJc0ltWnZieUlzSW1FaUxDSmlJbDBzSW0xaGNIQnBibWR6SWpvaU96dHJRa0ZCWVVFc1RVRkJUU3hEUVVGRFF5eEhPMGxCUVdaRExFTTdTVUZCUjBNc1F5SXNJbVpwYkdVaU9pSnBiaTVxY3lJc0luTnZkWEpqWlhORGIyNTBaVzUwSWpwYklteGxkQ0JiWVN3Z1lsMGdQU0IzYVc1a2IzY3VabTl2TzF4dUlsMTlcbiJdLCJuYW1lcyI6WyJ3aW5kb3ciLCJmb28iLCJhIiwiYiJdLCJtYXBwaW5ncyI6IjZCQUFhQSxPQUFPQyxJQUFmQyxFLGVBQUdDLEUiLCJmaWxlIjoiZXhhbXBsZS5qcyJ9,InVzZSBzdHJpY3QiOwoKdmFyIF93aW5kb3ckZm9vID0gd2luZG93LmZvbywKICAgIGEgPSBfd2luZG93JGZvb1swXSwKICAgIGIgPSBfd2luZG93JGZvb1sxXTsKLy8jIHNvdXJjZU1hcHBpbmdVUkw9ZGF0YTphcHBsaWNhdGlvbi9qc29uO2NoYXJzZXQ9dXRmODtiYXNlNjQsZXlKMlpYSnphVzl1SWpvekxDSnpiM1Z5WTJWeklqcGJJbWx1TG1weklsMHNJbTVoYldWeklqcGJJbmRwYm1SdmR5SXNJbVp2YnlJc0ltRWlMQ0ppSWwwc0ltMWhjSEJwYm1keklqb2lPenRyUWtGQllVRXNUVUZCVFN4RFFVRkRReXhITzBsQlFXWkRMRU03U1VGQlIwTXNReUlzSW1acGJHVWlPaUpwYmk1cWN5SXNJbk52ZFhKalpYTkRiMjUwWlc1MElqcGJJbXhsZENCYllTd2dZbDBnUFNCM2FXNWtiM2N1Wm05dk8xeHVJbDE5Cg==), but when fixed generates [this good output](http://sokra.github.io/source-map-visualization/#base64,InVzZSBzdHJpY3QiO3ZhciBfd2luZG93JGZvbz13aW5kb3cuZm9vLGE9X3dpbmRvdyRmb29bMF0sYj1fd2luZG93JGZvb1sxXTsKLyogYmFzZTY0IHNvdXJjZSBtYXAgcmVtb3ZlZCAqLw==,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImluLmpzIl0sInNvdXJjZXNDb250ZW50IjpbImxldCBbYSwgYl0gPSB3aW5kb3cuZm9vO1xuIl0sIm5hbWVzIjpbIndpbmRvdyIsImZvbyIsImEiLCJiIl0sIm1hcHBpbmdzIjoiNkJBQWFBLE9BQU9DLElBQWZDLEUsZUFBR0MsRSIsImZpbGUiOiJleGFtcGxlLmpzIn0=,bGV0IFthLCBiXSA9IHdpbmRvdy5mb287Cg==)

Uglify command line used to test: `uglifyjs --source-map "includeSources,content=inline,url=inline" in.js`

It looks like Uglify only does the wrong thing if the intermediate file is named the same as the original file - if the original file has a different name, Uglify correctly grabs the original provided sourcemap for that file, but if they're the same name, it blows away the provided sourcemap.