### PR TITLE
fix corner cases in arrow functions & `rests`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -762,10 +762,11 @@ merge(Compressor.prototype, {
                     return arg || make_node(AST_Undefined, iife);
                 }, visit);
             });
-            if (fn.rest) scan_declaration(tw, compressor, fn.rest, compressor.option("rests") && function() {
-                return make_node(AST_Array, fn, {
+            var rest = fn.rest;
+            if (rest) scan_declaration(tw, compressor, rest, compressor.option("rests") && function() {
+                return fn.rest === rest ? make_node(AST_Array, fn, {
                     elements: iife.args.slice(fn.argnames.length),
-                });
+                }) : rest;
             }, visit);
             walk_lambda(fn, tw);
             var safe_ids = tw.safe_ids;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1198,6 +1198,7 @@ function parse($TEXT, options) {
             }
         } else {
             body = [];
+            handle_regexp();
             value = maybe_assign();
         }
         S.input.pop_directives_stack();

--- a/test/compress/arrows.js
+++ b/test/compress/arrows.js
@@ -694,3 +694,12 @@ issue_4476: {
     expect_stdout: "foo bar"
     node_version: ">=4"
 }
+
+issue_4666: {
+    input: {
+        console.log((a => /[0-9]/.test(a))(42));
+    }
+    expect_exact: "console.log((a=>/[0-9]/.test(a))(42));"
+    expect_stdout: "true"
+    node_version: ">=4"
+}

--- a/test/compress/rests.js
+++ b/test/compress/rests.js
@@ -757,3 +757,30 @@ issue_4644_2: {
     expect_stdout: "PASS 0 undefined"
     node_version: ">=6"
 }
+
+issue_4666: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        rests: true,
+        toplevel: true,
+        unsafe: true,
+        unused: true,
+    }
+    input: {
+        var a = 0, b = 0;
+        var o = ((...c) => a++ + c)(b);
+        for (var k in o)
+            b++;
+        console.log(a, b);
+    }
+    expect: {
+        var a = 0, b = 0;
+        var o = (c => +a + c)([ b ]);
+        for(var k in o)
+            b++;
+        console.log(1, b);
+    }
+    expect_stdout: "1 2"
+    node_version: ">=6"
+}


### PR DESCRIPTION
fixes #4666