### PR TITLE
fix corner case in `reduce_vars`

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -624,6 +624,7 @@ merge(Compressor.prototype, {
             if (parent instanceof AST_Binary) return lazy_op[parent.operator];
             if (parent instanceof AST_Conditional) return parent.condition !== node;
             if (parent instanceof AST_Sequence) return parent.tail_node() === node;
+            if (parent instanceof AST_Spread) return true;
         }
 
         function mark_escaped(tw, d, scope, node, value, level, depth) {

--- a/test/compress/spreads.js
+++ b/test/compress/spreads.js
@@ -294,6 +294,31 @@ reduce_vars_2: {
     node_version: ">=6"
 }
 
+reduce_vars_3: {
+    options = {
+        reduce_funcs: true,
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        function f() {}
+        function g() {
+            return (a => a)(...[ f ]);
+        }
+        console.log(g() === g() ? "PASS" : "FAIL");
+    }
+    expect: {
+        function f() {}
+        function g() {
+            return (a => a)(...[ f ]);
+        }
+        console.log(g() === g() ? "PASS" : "FAIL");
+    }
+    expect_stdout: "PASS"
+    node_version: ">=6"
+}
+
 convert_setter: {
     options = {
         objects: true,


### PR DESCRIPTION
@kzc another one from `harmony` &minus; current patch for `test/compress.js`
```diff
--- a/test/compress.js
+++ b/test/compress.js
@@ -14 +14 @@ var batch = 50;
-var dir = path.resolve(path.dirname(module.filename), "compress");
+var dir = path.resolve(path.dirname(module.filename), "../../UglifyJS-harmony/test/compress");
@@ -141,0 +142 @@ function parse_test(file) {
+                    "reminify",
@@ -193,0 +195,4 @@ function reminify(orig_options, input_code, input_formatted, stdout) {
+        if ("keep_fnames" in orig_options) {
+            options.keep_fnames = orig_options.keep_fnames;
+            delete options.rename;
+        }
@@ -255,0 +261,11 @@ function test_case(test) {
+    [ "ecma" ].forEach(function(name) {
+        if (name in output_options) delete output_options[name];
+    });
+    if ("bracketize" in output_options) {
+        output_options.braces = output_options.bracketize;
+        delete output_options.bracketize;
+    }
+    if ("safari10" in output_options) {
+        output_options.webkit = output_options.safari10;
+        delete output_options.safari10;
+    }
@@ -308,0 +325,13 @@ function test_case(test) {
+    [
+        "computed_props",
+        "ecma",
+        "unsafe_arrows",
+        "unsafe_methods",
+        "warnings",
+    ].forEach(function(name) {
+        if (name in test.options) delete test.options[name];
+    });
+    if ("keep_classnames" in test.options) {
+        test.options.keep_fnames = test.options.keep_classnames;
+        delete test.options.keep_classnames;
+    }
@@ -319 +348 @@ function test_case(test) {
-    if (expect != output_code) {
+    if (0 && expect != output_code) {
@@ -359 +388 @@ function test_case(test) {
-    if (test.expect_warnings) {
+    if (0 && test.expect_warnings) {
@@ -390 +419 @@ function test_case(test) {
-        if (test.expect_stdout === true || test.expect_stdout instanceof Error && test.expect_stdout.name === actual.name) {
+        if (1 || test.expect_stdout === true || test.expect_stdout instanceof Error && test.expect_stdout.name === actual.name) {
```