### PR TITLE
fix for dropping unused default argument assignment for 3.13.7

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -6342,7 +6342,7 @@ merge(Compressor.prototype, {
                             } else if (trim) {
                                 log(sym.name, "Dropping unused default argument {name}");
                                 argnames.pop();
-                            } else if (i > default_length) {
+                            } else if (i >= default_length) {
                                 log(sym.name, "Dropping unused default argument assignment {name}");
                                 sym.name.__unused = true;
                                 argnames[i] = sym.name;


### PR DESCRIPTION
test source:
```js
function foo(a, b, c, d, e=5, f=11) {return a + c;};
```

output for v. 3.13.7
```js
function foo(n,o,f,r,t=0,u){return n+f}
```

with the fix: 
```js
function foo(n,o,f,r,t,u){return n+f}
```
