### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -77,7 +77,7 @@ function DEFNODE(type, props, methods, base) {
     ctor.SUBCLASSES = [];
     for (var name in methods) if (HOP(methods, name)) {
         if (/^\$/.test(name)) {
-            ctor[name.substr(1)] = methods[name];
+            ctor[name.slice(1)] = methods[name];
         } else {
             ctor.DEFMETHOD(name, methods[name]);
         }

--- a/lib/output.js
+++ b/lib/output.js
@@ -82,8 +82,8 @@ function OutputStream(options) {
         if (typeof options.comments === "string" && /^\/.*\/[a-zA-Z]*$/.test(options.comments)) {
             var regex_pos = options.comments.lastIndexOf("/");
             comments = new RegExp(
-                options.comments.substr(1, regex_pos - 1),
-                options.comments.substr(regex_pos + 1)
+                options.comments.slice(1, regex_pos),
+                options.comments.slice(regex_pos + 1)
             );
         }
         if (comments instanceof RegExp) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -297,7 +297,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
     }
 
     function looking_at(str) {
-        return S.text.substr(S.pos, str.length) == str;
+        return S.text.slice(S.pos, S.pos + str.length) == str;
     }
 
     function find_eol() {
@@ -449,7 +449,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         var regex_allowed = S.regex_allowed;
         var i = find_eol(), ret;
         if (i == -1) {
-            ret = S.text.substr(S.pos);
+            ret = S.text.slice(S.pos);
             S.pos = S.text.length;
         } else {
             ret = S.text.substring(S.pos, i);
@@ -489,7 +489,7 @@ function tokenizer($TEXT, filename, html5_comments, shebang) {
         }
         if (KEYWORDS[name] && escaped) {
             var hex = name.charCodeAt(0).toString(16).toUpperCase();
-            name = "\\u" + "0000".substr(hex.length) + hex + name.slice(1);
+            name = "\\u" + "0000".slice(hex.length) + hex + name.slice(1);
         }
         return name;
     }
@@ -816,7 +816,7 @@ function parse($TEXT, options) {
     function handle_regexp() {
         if (is("operator", "/") || is("operator", "/=")) {
             S.peeked = null;
-            S.token = S.input(S.token.value.substr(1)); // force regexp
+            S.token = S.input(S.token.value.slice(1)); // force regexp
         }
     }
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

