### PR TITLE
rename reserved keyword (await)

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1194,10 +1194,10 @@ function parse($TEXT, options) {
     }
 
     function for_() {
-        var await = is("name", "await") && next();
+        var awaitToken = is("name", "await") && next();
         expect("(");
         var init = null;
-        if (await || !is("punc", ";")) {
+        if (awaitToken || !is("punc", ";")) {
             init = is("keyword", "const")
                 ? (next(), const_(true))
                 : is("name", "let") && is_vardefs()
@@ -1206,7 +1206,7 @@ function parse($TEXT, options) {
                 ? (next(), var_(true))
                 : expression(true);
             var ctor;
-            if (await) {
+            if (awaitToken) {
                 expect_token("name", "of");
                 ctor = AST_ForAwaitOf;
             } else if (is("operator", "in")) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1194,10 +1194,10 @@ function parse($TEXT, options) {
     }
 
     function for_() {
-        var awaitToken = is("name", "await") && next();
+        var await_token = is("name", "await") && next();
         expect("(");
         var init = null;
-        if (awaitToken || !is("punc", ";")) {
+        if (await_token || !is("punc", ";")) {
             init = is("keyword", "const")
                 ? (next(), const_(true))
                 : is("name", "let") && is_vardefs()
@@ -1206,7 +1206,7 @@ function parse($TEXT, options) {
                 ? (next(), var_(true))
                 : expression(true);
             var ctor;
-            if (awaitToken) {
+            if (await_token) {
                 expect_token("name", "of");
                 ctor = AST_ForAwaitOf;
             } else if (is("operator", "in")) {


### PR DESCRIPTION
Since `await` is a reserved keyword, chrome won't run UglifyJS. This error exists since the update from `3.12.7` -> `3.12.8`