### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
     branches: [ master ]
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   ufuzz:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
   push:
     branches: [ master ]
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/ufuzz.yml
+++ b/.github/workflows/ufuzz.yml
@@ -11,6 +11,10 @@ on:
 env:
   BASE_URL: https://api.github.com/repos/${{ github.repository }}
   TOKEN: ${{ github.token }}
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   ufuzz:
     strategy:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.