### PR TITLE
Mozilla AST Extras ( Also a fix for #5834 )

### DIFF
--- a/lib/compress.js
+++ b/lib/compress.js
@@ -6275,7 +6275,7 @@ Compressor.prototype.compress = function(node) {
 
     // tell me if a statement aborts
     function aborts(thing) {
-        return thing && thing.aborts();
+        return thing && thing.aborts && thing.aborts();
     }
     (function(def) {
         def(AST_Statement, return_null);

--- a/lib/mozilla-ast.js
+++ b/lib/mozilla-ast.js
@@ -668,6 +668,7 @@
             type: "ArrowFunctionExpression",
             async: is_async(M),
             params: params,
+            expression: !!M.value,
             body: M.value ? to_moz(M.value) : to_moz_scope("BlockStatement", M),
         };
         return {


### PR DESCRIPTION
This pull request fixes:
- things.abort issue when using a converted Mozilla AST
- Compatibility issue with Mozilla AST ( #5834 )